### PR TITLE
Fix CI: build before test, not after

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,5 @@ jobs:
       - run: npm ci
       - run: npm audit
       - run: npm run typecheck
-      - run: npm run test
       - run: npm run build
+      - run: npm run test


### PR DESCRIPTION
The cliPairing integration test spawns the compiled out/cli/index.js to exercise the real bridge subcommand, but CI ran npm run test before npm run build — so out/cli never existed yet and the test failed with MODULE_NOT_FOUND on every fresh checkout. Reordered to typecheck -> build -> test, and dropped the now-redundant trailing build step.

## What does this change?

<!-- One or two sentences. Link the issue if there is one. -->

## Why?

<!-- The problem being solved. -->

## How was it tested?

<!-- Real servers, databases, platforms. Say if something could not be tested. -->

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] No credentials or key material logged, or sent to the renderer
- [x] New SSH work uses `acquire()` / `release()` rather than opening its own connection
- [x] New background work is gated on visibility, not on being mounted
- [x] State shape changes have a default in `replaceAll`
- [x] The related issue is linked, if this fixes or adds a known gap
