### PR TITLE
Publish the SHA-256 checksums the release notes promise

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,14 @@ jobs:
           rm -f artifacts/_defender.txt          # marker only; never a release asset
           VERSION="${TAG#v}"
           BASE="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+          # download-artifact nests one directory per build job, so find rather
+          # than a flat glob. Only the four installer types — .blockmap and
+          # latest*.yml are updater metadata nobody downloads by hand.
+          CHECKSUMS=$(cd artifacts && find . -type f \
+              \( -name '*.exe' -o -name '*.dmg' -o -name '*.AppImage' -o -name '*.deb' \) \
+            | sort \
+            | xargs -r sha256sum \
+            | awk '{ name = $2; sub(/.*\//, "", name); printf "| `%s` | `%s` |\n", name, $1 }')
           {
             echo "## Downloads"
             echo
@@ -212,7 +220,27 @@ jobs:
             fi
             echo "One or two detections from minor engines are normal for an unsigned"
             echo "Electron installer. Verify the SHA-256 of what you downloaded against"
-            echo "the value listed on this page, or build from source."
+            echo "the value listed below, or build from source."
+            echo
+            echo "## Checksums"
+            echo
+            echo "These are the whole reason an unsigned build is still safe to trust: they"
+            echo "prove the file you have is the file this workflow built. Check yours before"
+            echo "running it."
+            echo
+            echo '```bash'
+            echo "shasum -a 256 <file>                      # macOS, Linux"
+            echo "certutil -hashfile <file> SHA256          # Windows"
+            echo '```'
+            echo
+            echo "| File | SHA-256 |"
+            echo "|---|---|"
+            if [ -n "$CHECKSUMS" ]; then
+              echo "$CHECKSUMS"
+            else
+              # Never silently claim an empty table is the checksum list.
+              echo "| — | **Checksums could not be generated for this release.** |"
+            fi
             echo
             echo "---"
             echo
@@ -226,8 +254,9 @@ jobs:
             echo "**System Settings → Privacy & Security** and click **Open Anyway**. If you would"
             echo "rather use the Terminal, \`/usr/bin/xattr -cr /Applications/ShellPilot.app\` clears"
             echo "the quarantine flag (spelt with the full path, because a Homebrew or pip \`xattr\`"
-            echo "earlier on your PATH may not support \`-r\`). Each asset lists its SHA-256, which"
-            echo "is the strongest integrity check available here."
+            echo "earlier on your PATH may not support \`-r\`). Every installer's SHA-256 is"
+            echo "listed under Checksums above, which is the strongest integrity check available"
+            echo "here."
             echo
           } > release-notes.md
           cat release-notes.md


### PR DESCRIPTION
The release notes have claimed **"Each asset lists its SHA-256"** since the first release. Nothing ever computed one.

`v0.3.0` shipped with zero checksums — the asset tables are `| File | Notes |` and no step in the workflow runs `sha256sum`. Meanwhile:

- the notes tell users to *"verify the SHA-256 of what you downloaded against the value listed on this page"*
- [README.md:38](README.md) offers checksums in the top caution box as the reassurance that stands in **for** code signing
- the "Verifying a download" section walks through comparing them

For an unsigned app that's the load-bearing integrity claim, and a user following the advice had nothing to compare against.

## Change

Adds a **Checksums** section listing every installer with its SHA-256, plus the verification command per platform.

- Walks the tree with `find` rather than a flat glob — `download-artifact` nests one directory per build job
- Covers the four installer types only; `.blockmap` and `latest*.yml` are updater metadata nobody downloads by hand, and the notes already say so
- An empty result prints an explicit failure row, so a broken hash step can't quietly pass for a list of hashes

## Verification

Ran the pipeline against a simulated nested `artifacts/` tree: 6 installers hashed, blockmaps and yml excluded, paths stripped to bare filenames. YAML parses.

`v0.3.0`'s own notes are being backfilled separately from the digests GitHub already publishes for each asset — no rebuild needed. Those digests were cross-checked against a hash computed locally from a fresh download of the arm64 dmg, and matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)