### PR TITLE
Actually publish the release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,10 +261,41 @@ jobs:
           } > release-notes.md
           cat release-notes.md
 
+      # Uploads the assets only. The notes are set in the next step instead,
+      # because append_body silently did nothing here: when a release already
+      # exists for the tag the action reuses it ("Using release N ... instead of
+      # duplicate draft M") and the appended body never landed. Every release up
+      # to and including v0.3.0 shipped with an empty body because of it —
+      # downloads table, scan results, install guidance and all.
       - uses: softprops/action-gh-release@v2
         with:
           files: artifacts/**
-          body_path: release-notes.md
-          append_body: true
-          generate_release_notes: true
           draft: false
+
+      # Set the body explicitly, then check it is actually there. A release
+      # whose notes quietly vanish is worse than a failed job, because nothing
+      # about the run looks wrong.
+      - name: Publish release notes
+        env:
+          TAG: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # GitHub's own "What's Changed" section, kept below our notes rather
+          # than lost to overwriting the body.
+          gh api "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+            -f tag_name="$TAG" --jq .body > generated.md || : > generated.md
+
+          cp release-notes.md final-notes.md
+          if [ -s generated.md ]; then
+            { echo; echo "---"; echo; cat generated.md; } >> final-notes.md
+          fi
+
+          gh release edit "$TAG" --notes-file final-notes.md
+
+          LEN=$(gh release view "$TAG" --json body --jq '(.body // "") | length')
+          echo "Release body is $LEN characters."
+          if [ "$LEN" -lt 200 ]; then
+            echo "::error::Release notes did not publish (body is $LEN chars). The assets are"
+            echo "::error::uploaded but the release page is empty — fix before announcing."
+            exit 1
+          fi


### PR DESCRIPTION
**Every release so far has an empty body.** `v0.2.2` and `v0.3.0` both return 0 characters from the API.

The downloads table, the antivirus scan results, the first-run instructions, and the checksums added in #4 — none of it has ever been visible on a release page.

## What was happening

The `Build release notes` step always ran and wrote `release-notes.md`. The upload step just never applied it. From the v0.3.0 publish log:

```
👩‍🏭 Creating new GitHub release for tag v0.3.0...
↪️ Using release 377060844 for tag v0.3.0 instead of duplicate draft 377065173
🧹 Removing duplicate draft release 377065173 for tag v0.3.0...
```

When a release already exists for the tag the action reuses it, and `append_body` against that path didn't take.

## Change

Rather than work out which combination of `append_body` and `generate_release_notes` behaves, the action now uploads assets only and the body is set explicitly with `gh release edit`. That's the same call I used to backfill v0.3.0 by hand — it worked, so the mechanism is proven even though a workflow change can't be fully exercised without cutting a release.

GitHub's generated "What's Changed" is fetched separately and kept **below** our notes instead of being lost to overwriting the body.

**And then it checks.** The job fails if the published body comes back under 200 characters. The failure mode here was silence — assets upload, every step goes green, release page blank — and that's exactly what should have been loud.

## Already done

`v0.3.0`'s notes are backfilled and live, with real checksums taken from the digests GitHub publishes per asset. The arm64 digest was cross-checked against a SHA-256 computed locally from a fresh download of that dmg, and matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)