### PR TITLE
Vault-backed credentials, Touch ID unlock, service and port monitoring

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,12 @@ on:
 permissions:
   contents: write
 
+# Re-pushing a tag, or two tags in quick succession, would otherwise run two
+# release jobs editing the same release body at once.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build ${{ matrix.os }}
@@ -92,7 +98,9 @@ jobs:
             release/*.deb
             release/*.blockmap
             release/_defender.txt
-          if-no-files-found: warn
+          # A silent no-op here would publish a release whose notes link to
+          # files that were never built.
+          if-no-files-found: error
 
   release:
     name: Publish release
@@ -275,9 +283,15 @@ jobs:
       # to and including v0.3.0 shipped with an empty body because of it —
       # downloads table, scan results, install guidance and all.
       - uses: softprops/action-gh-release@v2
+        id: gh_release
         with:
           files: artifacts/**
-          draft: false
+          # Stays invisible until the notes are confirmed on the page. Assets
+          # used to go public here and the body was set afterwards, so every
+          # way the notes step could fail left a published, watcher-notified,
+          # empty-bodied release — which the guard below could detect but not
+          # undo. A draft sends no notifications and is not /releases/latest.
+          draft: true
 
       # Set the body explicitly, then check it is actually there. A release
       # whose notes quietly vanish is worse than a failed job, because nothing
@@ -299,10 +313,35 @@ jobs:
 
           gh release edit "$TAG" --notes-file final-notes.md
 
-          LEN=$(gh release view "$TAG" --json body --jq '(.body // "") | length')
-          echo "Release body is $LEN characters."
-          if [ "$LEN" -lt 200 ]; then
-            echo "::error::Release notes did not publish (body is $LEN chars). The assets are"
-            echo "::error::uploaded but the release page is empty — fix before announcing."
+          # Check what is actually on the page, not how long it is. A length
+          # test passes on any body over the threshold, including one with none
+          # of our content in it — so it could not detect the failure it was
+          # written for. Every checksum and every download link must be there.
+          gh release view "$TAG" --json body --jq '.body // ""' > remote.md
+
+          grep -oE '[a-f0-9]{64}' final-notes.md | sort -u > expected.txt
+          grep -oE 'https://github\.com/[^)]*/releases/download/[^)]+' final-notes.md | sort -u >> expected.txt
+
+          if [ ! -s expected.txt ]; then
+            echo "::error::The generated notes contain no checksums or download links at all."
             exit 1
           fi
+
+          MISSING=0
+          while IFS= read -r token; do
+            [ -z "$token" ] && continue
+            if ! grep -qF -- "$token" remote.md; then
+              echo "::error::Missing from the published notes: $token"
+              MISSING=1
+            fi
+          done < expected.txt
+
+          if [ "$MISSING" -ne 0 ]; then
+            echo "::error::The release is still a draft, so nothing is public. Fix and re-run."
+            exit 1
+          fi
+
+          echo "Verified $(wc -l < expected.txt) checksums and links on the published page."
+
+          # Confirmed on the page. Only now does anyone see it.
+          gh release edit "$TAG" --draft=false --latest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,21 @@ Knowing the design may help you assess a finding.
 | AI/MCP audit log | `shellpilot-ai-audit.jsonl` | Plaintext, append-only. Free-text fields are passed through the same secret-redaction as command output before being written, so it should never contain a credential. |
 | AI/MCP access-group policy | `shellpilot-ai-policy.json` | Plaintext. Contains no credentials — capability rules and file-path patterns only. |
 
+### Workspaces and the vault
+
+Workspaces isolate **servers, databases and tunnels** — each record carries a
+workspace id and is filtered by it. A password-protected workspace keeps those
+out of sight until it is unlocked.
+
+**The vault is not workspace-scoped.** There is one vault per installation,
+shared by every workspace, and a credential saved in one workspace is visible
+from all of them. Locking a workspace does not hide the vault, because the
+vault does not belong to any workspace.
+
+That is the current design, not an oversight in the filtering — but it is easy
+to expect otherwise if you use one workspace per client, so it is stated here
+plainly.
+
 ### What biometric unlock actually protects
 
 Worth stating plainly, because it is easy to assume more.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ Knowing the design may help you assess a finding.
 |---|---|---|
 | SSH passwords, key paths, key passphrases | `shellpilot-secrets.json` | Electron `safeStorage` — DPAPI / Keychain / libsecret. Machine and user bound. |
 | Vault entries | `shellpilot-vault.json` | AES-256-GCM, key from the master password via scrypt (N=32768). Password never stored. Decrypted entries are sent to the renderer while the vault is open, so they live in the renderer's memory too — not only in the main process. |
-| Biometric unlock key (opt-in, off by default) | `shellpilot-vault-bio.json` | The vault's **derived key**, wrapped with Electron `safeStorage`. Present only if you enable Touch ID unlock. The master password is not stored, but see below — this is the weakest protection any vault data gets. |
+| Biometric unlock key (opt-in, off by default) | main-process memory, or `shellpilot-vault-bio.json` | The vault's **derived key**, wrapped with Electron `safeStorage`. By default this is held in memory only and dies with the process, so nothing is written to disk. The file exists only if you explicitly choose to keep biometric unlock across restarts. |
 | Workspace passwords | `shellpilot-wslocks.json` | scrypt verifier with a random salt, compared with `timingSafeEqual`. Not reversible. |
 | Trusted SSH host keys | `shellpilot-known-hosts.json` | SHA-256 fingerprints, plaintext (not secret). |
 | Backups | user-chosen `.spbackup` file | AES-256-GCM under a passphrase you supply. Credentials are unsealed from the keychain and re-encrypted so the file is portable. |
@@ -58,6 +58,16 @@ which requires entitlements authorised by a provisioning profile, which requires
 a paid Apple Developer account. ShellPilot is ad-hoc signed and has none, so
 neither is available to it. (Apple's TN3137 documents this; it is the design, not
 a gap we have failed to close.)
+
+This is why biometric unlock is **session-scoped by default**: the wrapped key
+is held in main-process memory and dies with the app, so an attacker who can
+read your files finds nothing to read. You type the master password once per
+launch and Touch ID reopens the vault after that. It is the same design
+KeePassXC uses, and it is what makes the feature defensible without the
+entitlements above.
+
+Keeping it across restarts is a separate, explicit choice, and it is the one
+that writes the key to disk.
 
 Two consequences worth being concrete about:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,8 @@ Knowing the design may help you assess a finding.
 | Data | Storage | Protection |
 |---|---|---|
 | SSH passwords, key paths, key passphrases | `shellpilot-secrets.json` | Electron `safeStorage` — DPAPI / Keychain / libsecret. Machine and user bound. |
-| Vault entries | `shellpilot-vault.json` | AES-256-GCM, key from the master password via scrypt (N=32768). Password never stored. |
+| Vault entries | `shellpilot-vault.json` | AES-256-GCM, key from the master password via scrypt (N=32768). Password never stored. Decrypted entries are sent to the renderer while the vault is open, so they live in the renderer's memory too — not only in the main process. |
+| Biometric unlock key (opt-in, off by default) | `shellpilot-vault-bio.json` | The vault's **derived key**, wrapped with Electron `safeStorage`. Present only if you enable Touch ID unlock. The master password is not stored, but see below — this is the weakest protection any vault data gets. |
 | Workspace passwords | `shellpilot-wslocks.json` | scrypt verifier with a random salt, compared with `timingSafeEqual`. Not reversible. |
 | Trusted SSH host keys | `shellpilot-known-hosts.json` | SHA-256 fingerprints, plaintext (not secret). |
 | Backups | user-chosen `.spbackup` file | AES-256-GCM under a passphrase you supply. Credentials are unsealed from the keychain and re-encrypted so the file is portable. |
@@ -40,6 +41,35 @@ Knowing the design may help you assess a finding.
 | AI/MCP agent sessions | `shellpilot-mcp-sessions.json` | Only a SHA-256 hash and a 4-character preview of the bearer token is stored — never the raw token. |
 | AI/MCP audit log | `shellpilot-ai-audit.jsonl` | Plaintext, append-only. Free-text fields are passed through the same secret-redaction as command output before being written, so it should never contain a credential. |
 | AI/MCP access-group policy | `shellpilot-ai-policy.json` | Plaintext. Contains no credentials — capability rules and file-path patterns only. |
+
+### What biometric unlock actually protects
+
+Worth stating plainly, because it is easy to assume more.
+
+Electron's `promptTouchID` authenticates the person at the keyboard. It does not
+return a key. So enabling Touch ID unlock stores the vault's derived key on disk
+under `safeStorage`, with a biometric prompt in front of reading it — a **gate**,
+not a cryptographic binding. Software running under your macOS account can read
+that key without ever triggering the prompt.
+
+The stronger designs — a Keychain item with a biometry ACL, or a Secure Enclave
+key wrapping the vault key — both require the macOS data-protection keychain,
+which requires entitlements authorised by a provisioning profile, which requires
+a paid Apple Developer account. ShellPilot is ad-hoc signed and has none, so
+neither is available to it. (Apple's TN3137 documents this; it is the design, not
+a gap we have failed to close.)
+
+Two consequences worth being concrete about:
+
+- With biometric unlock **off**, the master password exists nowhere on the
+  machine, and the vault is the only ShellPilot data an attacker with your files
+  and your logged-in session cannot read. Turning it on gives that up.
+- Your SSH credentials in `shellpilot-secrets.json` have always been protected
+  by `safeStorage` alone. So enabling this moves the vault down to the protection
+  the rest of the app already has, rather than opening a new category of risk.
+
+It remains a real barrier against someone who picks up an unlocked laptop, and it
+is why the feature exists. It is not a barrier against code running as you.
 
 ## Known limitations
 

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    Unused until a Developer ID certificate exists; electron-builder.yml
+    references it only when hardenedRuntime is turned on. Written now so
+    enabling signing is a configuration change rather than a research task.
+
+    Library validation must be disabled: asarUnpack deliberately keeps the ssh2
+    and cpu-features .node binaries outside the archive, and hardened runtime
+    would otherwise refuse to load them. Turning it off gives back that one
+    protection while keeping the two that matter most here — DYLD_INSERT_LIBRARIES
+    injection and debugger attach stay blocked, which is what stops a process
+    running as the same user reading an unlocked vault key out of memory.
+  -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+
+  <!--
+    Electron needs these regardless; without them the renderer cannot start
+    under hardened runtime.
+  -->
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+</dict>
+</plist>

--- a/docs/AI-MCP.md
+++ b/docs/AI-MCP.md
@@ -47,7 +47,7 @@ another MCP client. For the short pitch and the security summary, see the
 
 ## The MCP server
 
-`src/main/services/mcpServer.ts` registers **9 tools**:
+`src/main/services/mcpServer.ts` registers **13 tools**:
 
 | Tool | Capability gating it | What it returns |
 |---|---|---|
@@ -60,6 +60,10 @@ another MCP client. For the short pitch and the security summary, see the
 | `list_files` | `readFiles` + `sftpDownload` (+ file path rules) | Directory listing |
 | `get_server_metrics` | `serverMetrics` | CPU/memory/disk/uptime |
 | `add_server` | `manageServers`, resolved on the **workspace** | The name the new connection was saved under |
+| `list_databases` | `viewServer` | Friendly names and engines, never a host or credential |
+| `query_database` | `databaseAccess` for reads; `+ writeFiles` and always ASK for anything that writes | Rows, capped |
+| `list_tunnels` | `sshTunnel` | Configured tunnels and whether each is running |
+| `set_tunnel` | `sshTunnel`, always ASK to start | Confirmation, with the bound port |
 
 Each tool carries a `title`, an MCP annotation set (`readOnlyHint`, `destructiveHint`,
 `openWorldHint`) and a description of every parameter, and the server sends `instructions` on
@@ -78,6 +82,25 @@ This is best-effort by design: only absolute paths and only recognised commands,
 relative operand cannot be matched against a pattern without knowing the remote working directory.
 `cd /root/.ssh && cat id_rsa` still gets through. It closes the direct form and can only ever
 narrow a decision, never widen one.
+
+### Databases and tunnels
+
+`query_database` classifies the statement before running it. Reads are governed by
+`databaseAccess` alone; anything that modifies data or schema is additionally bounded by
+`writeFiles` — a group whose point is that it cannot change anything should not be able to change
+a row either — and can never resolve better than ASK. That clamp exists because `databaseAccess`
+defaults to ALLOW in every built-in group, so honouring it plainly would have handed a Full Access
+agent a silent `DROP TABLE`.
+
+A read cannot smuggle a write behind a semicolon, comments cannot hide the verb, and an
+unrecognised verb counts as a write: there are too many dialects to enumerate and guessing
+"harmless" is the expensive direction to be wrong in. Mongo shell syntax is classified separately,
+since `db.users.find({})` leads with the collection rather than the verb.
+
+`set_tunnel` can only start or stop a tunnel the user has already defined — it cannot create one or
+change where an existing one points. Starting always requires approval whatever the group says,
+because it binds a listening port on the user's own machine. Stopping does not, being the safe
+direction.
 
 ### `add_server`
 
@@ -108,9 +131,8 @@ Descriptions are written to route an agent to the narrowest tool that does the j
 cannot be added without it.
 
 There is no `vault` tool. The MCP server has no code path into the Vault at all — an AI session
-cannot read a Vault entry no matter what access group it holds. There are no tunnel or database
-tools either; the `sshTunnel` and `databaseAccess` capabilities exist in the access-group model but
-nothing is gated on them yet.
+cannot read a Vault entry no matter what access group it holds, including when a server's
+credential is stored there.
 
 The server also exposes two unauthenticated bootstrap endpoints used only by the CLI pairing flow:
 `POST /pair/start` and `POST /pair/confirm` (see [Pairing](#the-shellpilot-cli-and-pairing) below).

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -68,6 +68,20 @@ mac:
   # "damaged", a dialog with no Open Anyway button. Signing ad-hoc ourselves seals
   # the real bundle, so the app fails the ordinary "cannot be verified" way that
   # users can click through. It is still not notarized.
+  # When a Developer ID certificate is available, this whole block becomes:
+  #
+  #   identity: 'Developer ID Application: <NAME> (<TEAM_ID>)'
+  #   hardenedRuntime: true
+  #   entitlements: build/entitlements.mac.plist
+  #   entitlementsInherit: build/entitlements.mac.plist
+  #   notarize: true          # plus APPLE_ID / APPLE_APP_SPECIFIC_PASSWORD / APPLE_TEAM_ID in CI
+  #
+  # That one change removes the Gatekeeper warning entirely, and it is also what
+  # unlocks hardened runtime (see below), a stable signing identity so keychain
+  # ACLs survive updates, and the data-protection keychain that biometry ACLs
+  # and Secure Enclave keys require. build/entitlements.mac.plist is already
+  # written and carries the library-validation exception the unpacked ssh2 and
+  # cpu-features binaries need.
   identity: '-'
   # Hardened runtime turns on library validation, which refuses to load the
   # ssh2/cpu-features .node binaries that asarUnpack deliberately keeps outside

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -71,9 +71,16 @@ mac:
   identity: '-'
   # Hardened runtime turns on library validation, which refuses to load the
   # ssh2/cpu-features .node binaries that asarUnpack deliberately keeps outside
-  # the archive. It only buys anything alongside notarization, which we have no
-  # certificate for, so leave it off rather than carry an entitlements plist that
-  # exists purely to switch its side effects back off.
+  # the archive, so it is off here.
+  #
+  # Note this is a real cost, not a free choice: DYLD_INSERT_LIBRARIES injection
+  # and debugger attach are blocked by the hardened runtime regardless of
+  # notarization, so leaving it off means a process running as the same user can
+  # inject into ShellPilot and read an unlocked vault key straight out of memory.
+  # Turning it on needs com.apple.security.cs.disable-library-validation for the
+  # .node binaries — which gives back the library-validation half but keeps the
+  # DYLD and debugger hardening. Worth doing; it needs an entitlements plist and
+  # a build to verify the native modules still load.
   hardenedRuntime: false
   target:
     - target: dmg

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "electron-builder": "^26.15.3",
         "electron-vite": "^5.0.0",
         "esbuild": "^0.25.12",
+        "js-yaml": "^4.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "typescript": "^5.7.2",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "electron": "^43.4.1",
     "electron-builder": "^26.15.3",
     "electron-vite": "^5.0.0",
+    "js-yaml": "^4.1.0",
     "esbuild": "^0.25.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -511,6 +511,7 @@ ipcMain.handle('vault:bio-enable', (_e, scope: 'session' | 'persistent' = 'sessi
   enableBiometricUnlock(scope)
 )
 ipcMain.handle('vault:bio-scope', () => biometricScope())
+ipcMain.handle('vault:set-auto-lock', (_e, minutes: number) => setVaultAutoLock(minutes))
 ipcMain.handle('vault:bio-disable', () => disableBiometricUnlock())
 ipcMain.handle('vault:bio-unlock', () => biometricUnlock())
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -56,7 +56,7 @@ import { checkForUpdates, getUpdaterStatus, onUpdaterStatus, installUpdate, open
 import { parseSshConfig } from '../shared/sshconfig'
 import { loadData, saveData } from './services/store'
 import type { SshConnectConfig } from '../shared/ssh'
-import { resolveChainSecrets, type SecretBlob } from './services/credentialResolver'
+import { resolveDbSecrets, resolveChainSecrets, type SecretBlob } from './services/credentialResolver'
 import { refreshMcpDataCache, listCachedWorkspaces, listCachedServers } from './services/mcpDataCache'
 import {
   listGroups,
@@ -395,28 +395,10 @@ ipcMain.handle('metrics:sample', (_e, key: string, cfg: SshConnectConfig & { ser
 ipcMain.handle('metrics:disconnect', (_e, key: string) => metricsDisconnect(key))
 
 // ---- Databases ----
-function withDbSecret(cfg: DbConnectConfig): DbConnectConfig {
-  if (!cfg.password && !cfg.uri) {
-    const raw = getSecret(cfg.id)
-    if (raw) {
-      try {
-        const b = JSON.parse(raw) as { password?: string; uri?: string }
-        cfg.password = b.password
-        cfg.uri = b.uri
-      } catch {
-        cfg.password = raw // legacy plain-password secret
-      }
-    }
-  }
-  // The jump host's own credentials live in the same encrypted store, keyed by
-  // the server id.
-  if (cfg.ssh) cfg.ssh = resolveChainSecrets({ ...cfg.ssh })
-  return cfg
-}
-ipcMain.handle('db:test', (_e, cfg: DbConnectConfig) => dbTest(withDbSecret(cfg)))
-ipcMain.handle('db:query', (_e, cfg: DbConnectConfig, text: string) => dbQuery(withDbSecret(cfg), text))
-ipcMain.handle('db:info', (_e, cfg: DbConnectConfig) => dbInfo(withDbSecret(cfg)))
-ipcMain.handle('db:shell', (_e, cfg: DbConnectConfig, line: string) => dbShell(withDbSecret(cfg), line))
+ipcMain.handle('db:test', (_e, cfg: DbConnectConfig) => dbTest(resolveDbSecrets(cfg)))
+ipcMain.handle('db:query', (_e, cfg: DbConnectConfig, text: string) => dbQuery(resolveDbSecrets(cfg), text))
+ipcMain.handle('db:info', (_e, cfg: DbConnectConfig) => dbInfo(resolveDbSecrets(cfg)))
+ipcMain.handle('db:shell', (_e, cfg: DbConnectConfig, line: string) => dbShell(resolveDbSecrets(cfg), line))
 ipcMain.handle('db:close', (_e, id: string) => dbClose(id))
 
 // ---- SSH config import ----

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -85,6 +85,13 @@ import { onCliPairingEvent, cancelCliPairing } from './services/cliPairing'
 import { claudeCodeCommand, writeClaudeDesktopConfig, writeCodexConfig } from './services/clientConfig'
 import { setAgentServerCreator, type AgentServerRequest, type AgentServerResult } from './services/agentServerCreate'
 import { listDefaultKeys, sshDir } from './services/sshKeys'
+import {
+  biometricSupport,
+  biometricEnabled,
+  enableBiometricUnlock,
+  disableBiometricUnlock,
+  biometricUnlock
+} from './services/biometrics'
 import { listAudit } from './services/auditLog'
 import { startMcpServer, stopMcpServer, mcpServerStatus, explainSessionAccess } from './services/mcpServer'
 
@@ -484,10 +491,28 @@ ipcMain.handle('vault:unlock', (_e, password: string) => vaultUnlock(password))
 ipcMain.handle('vault:lock', () => vaultLock())
 ipcMain.handle('vault:list', () => vaultList())
 ipcMain.handle('vault:save', (_e, entries: VaultEntry[]) => vaultSave(entries))
-ipcMain.handle('vault:change-password', (_e, current: string, next: string) =>
-  vaultChangePassword(current, next)
-)
-ipcMain.handle('vault:destroy', () => vaultDestroy())
+// The stored biometric key was derived from the old password and cannot open
+// the re-encrypted vault, so it is cleared here rather than left to fail on
+// the next unlock. The renderer re-reads bio-enabled after this and tells the
+// user to set it up again.
+ipcMain.handle('vault:change-password', async (_e, current: string, next: string) => {
+  const result = await vaultChangePassword(current, next)
+  if (result.ok) disableBiometricUnlock()
+  return result
+})
+ipcMain.handle('vault:destroy', () => {
+  // A stored biometric key opens a vault that no longer exists; leaving it
+  // behind is dead material on disk.
+  disableBiometricUnlock()
+  return vaultDestroy()
+})
+
+// ---- Vault: biometric unlock ----
+ipcMain.handle('vault:bio-support', () => biometricSupport())
+ipcMain.handle('vault:bio-enabled', () => biometricEnabled())
+ipcMain.handle('vault:bio-enable', () => enableBiometricUnlock())
+ipcMain.handle('vault:bio-disable', () => disableBiometricUnlock())
+ipcMain.handle('vault:bio-unlock', () => biometricUnlock())
 
 // ---- Workspace locks ----
 ipcMain.handle('wslock:ids', () => wsLockIds())

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -88,8 +88,10 @@ import { listDefaultKeys, sshDir } from './services/sshKeys'
 import {
   biometricSupport,
   biometricEnabled,
+  biometricScope,
   enableBiometricUnlock,
   disableBiometricUnlock,
+  forgetSessionKey,
   biometricUnlock
 } from './services/biometrics'
 import { listAudit } from './services/auditLog'
@@ -470,7 +472,12 @@ ipcMain.handle('tunnel:list', () => tunnelList())
 ipcMain.handle('vault:status', () => vaultStatus())
 ipcMain.handle('vault:create', (_e, password: string) => vaultCreate(password))
 ipcMain.handle('vault:unlock', (_e, password: string) => vaultUnlock(password))
-ipcMain.handle('vault:lock', () => vaultLock())
+ipcMain.handle('vault:lock', () => {
+  // A session-scoped biometric key must not outlive the unlocked state, or
+  // "lock" would not mean locked.
+  forgetSessionKey()
+  return vaultLock()
+})
 ipcMain.handle('vault:list', () => vaultList())
 ipcMain.handle('vault:save', (_e, entries: VaultEntry[]) => vaultSave(entries))
 // The stored biometric key was derived from the old password and cannot open
@@ -492,7 +499,10 @@ ipcMain.handle('vault:destroy', () => {
 // ---- Vault: biometric unlock ----
 ipcMain.handle('vault:bio-support', () => biometricSupport())
 ipcMain.handle('vault:bio-enabled', () => biometricEnabled())
-ipcMain.handle('vault:bio-enable', () => enableBiometricUnlock())
+ipcMain.handle('vault:bio-enable', (_e, scope: 'session' | 'persistent' = 'session') =>
+  enableBiometricUnlock(scope)
+)
+ipcMain.handle('vault:bio-scope', () => biometricScope())
 ipcMain.handle('vault:bio-disable', () => disableBiometricUnlock())
 ipcMain.handle('vault:bio-unlock', () => biometricUnlock())
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -85,6 +85,7 @@ import { onCliPairingEvent, cancelCliPairing } from './services/cliPairing'
 import { claudeCodeCommand, writeClaudeDesktopConfig, writeCodexConfig } from './services/clientConfig'
 import { setAgentServerCreator, type AgentServerRequest, type AgentServerResult } from './services/agentServerCreate'
 import { listDefaultKeys, sshDir } from './services/sshKeys'
+import { setVaultAutoLock } from './services/vault'
 import {
   biometricSupport,
   biometricEnabled,
@@ -472,6 +473,13 @@ ipcMain.handle('tunnel:list', () => tunnelList())
 ipcMain.handle('vault:status', () => vaultStatus())
 ipcMain.handle('vault:create', (_e, password: string) => vaultCreate(password))
 ipcMain.handle('vault:unlock', (_e, password: string) => vaultUnlock(password))
+// Auto-lock needs the renderer told, or the UI keeps showing an unlocked vault
+// it can no longer read. The biometric session key goes with it.
+setVaultAutoLock(15, () => {
+  forgetSessionKey()
+  if (mainWindow && !mainWindow.isDestroyed()) mainWindow.webContents.send('vault:auto-locked')
+})
+
 ipcMain.handle('vault:lock', () => {
   // A session-scoped biometric key must not outlive the unlocked state, or
   // "lock" would not mean locked.

--- a/src/main/services/biometrics.ts
+++ b/src/main/services/biometrics.ts
@@ -1,0 +1,137 @@
+import { app, safeStorage, systemPreferences } from 'electron'
+import { join } from 'node:path'
+import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs'
+import { vaultExportKey, vaultUnlockWithKey, vaultStatus } from './vault'
+import type { VaultResult } from '../../shared/vault'
+
+// Biometric unlock for the vault.
+//
+// What this is, stated plainly, because the difference matters. Touch ID here
+// is a GATE, not a key: Electron's promptTouchID authenticates the person at
+// the keyboard, it does not hand back a Secure Enclave key bound to that
+// authentication. So enabling this stores the vault's derived key on disk,
+// encrypted with safeStorage — the OS keychain on macOS, DPAPI on Windows,
+// libsecret on Linux — and puts a biometric prompt in front of reading it.
+//
+// The trade that buys: the vault opens with a fingerprint instead of a
+// master password. The trade that costs: the key is now recoverable by
+// anything able to read this file AND call safeStorage as this OS user, where
+// before it existed only in memory and only after someone typed the password.
+// That is a real reduction, which is why this is opt-in, off by default, and
+// says so where it is switched on.
+//
+// The master password is never stored — only the derived key, so the password
+// itself cannot be recovered from this file even by someone who defeats both.
+
+const FILE = join(app.getPath('userData'), 'shellpilot-vault-bio.json')
+
+export type BiometricKind = 'touch-id' | 'windows-hello' | 'none'
+
+export interface BiometricSupport {
+  available: boolean
+  kind: BiometricKind
+  // Why it is unavailable, for the UI to show instead of an inert switch.
+  reason?: string
+}
+
+interface StoredKey {
+  version: 1
+  kind: BiometricKind
+  key: string
+  salt: string
+}
+
+export function biometricSupport(): BiometricSupport {
+  if (!safeStorage.isEncryptionAvailable()) {
+    return { available: false, kind: 'none', reason: 'This system has no secure storage available.' }
+  }
+  if (process.platform === 'darwin') {
+    // canPromptTouchID is false on a Mac with no Touch Bar/sensor, and on one
+    // where the user has not enrolled a fingerprint.
+    return systemPreferences.canPromptTouchID()
+      ? { available: true, kind: 'touch-id' }
+      : { available: false, kind: 'none', reason: 'No enrolled Touch ID fingerprint on this Mac.' }
+  }
+  if (process.platform === 'win32') {
+    // Windows Hello has no Electron API; it needs a native module binding
+    // Windows.Security.Credentials.UI. Deliberately not pulled in for this —
+    // a native dependency changes the build for all three platforms. The shape
+    // here is ready for it: a provider that can prompt, plus safeStorage
+    // (DPAPI) for the key, which is already what the other branches use.
+    return { available: false, kind: 'none', reason: 'Windows Hello is not supported yet.' }
+  }
+  return { available: false, kind: 'none', reason: 'Biometric unlock is not supported on this platform.' }
+}
+
+function read(): StoredKey | null {
+  try {
+    if (!existsSync(FILE)) return null
+    return JSON.parse(readFileSync(FILE, 'utf8')) as StoredKey
+  } catch {
+    return null
+  }
+}
+
+export function biometricEnabled(): boolean {
+  return read() !== null
+}
+
+export function disableBiometricUnlock(): VaultResult {
+  try {
+    if (existsSync(FILE)) unlinkSync(FILE)
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: (err as Error).message }
+  }
+}
+
+// Requires the vault to be unlocked already, because the key being stored is
+// the one currently in memory. There is no path here that turns a biometric
+// into access the caller did not already have.
+export function enableBiometricUnlock(): VaultResult {
+  const support = biometricSupport()
+  if (!support.available) return { ok: false, error: support.reason ?? 'Biometric unlock is unavailable.' }
+  if (!vaultStatus().unlocked) return { ok: false, error: 'Unlock the vault first.' }
+
+  const exported = vaultExportKey()
+  if (!exported) return { ok: false, error: 'Unlock the vault first.' }
+
+  try {
+    const payload: StoredKey = {
+      version: 1,
+      kind: support.kind,
+      key: safeStorage.encryptString(exported.key.toString('base64')).toString('base64'),
+      salt: exported.salt.toString('base64')
+    }
+    writeFileSync(FILE, JSON.stringify(payload), { mode: 0o600 })
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, error: `Could not store the key: ${(err as Error).message}` }
+  }
+}
+
+export async function biometricUnlock(reason = 'unlock your ShellPilot vault'): Promise<VaultResult> {
+  const stored = read()
+  if (!stored) return { ok: false, error: 'Biometric unlock is not set up for this vault.' }
+  const support = biometricSupport()
+  if (!support.available) return { ok: false, error: support.reason ?? 'Biometric unlock is unavailable.' }
+
+  try {
+    if (support.kind === 'touch-id') await systemPreferences.promptTouchID(reason)
+  } catch (err) {
+    // A cancelled prompt is not a failure worth alarming about; the caller
+    // falls back to the password field either way.
+    return { ok: false, error: (err as Error).message || 'Biometric authentication was cancelled.' }
+  }
+
+  try {
+    const key = Buffer.from(safeStorage.decryptString(Buffer.from(stored.key, 'base64')), 'base64')
+    const result = vaultUnlockWithKey(key, Buffer.from(stored.salt, 'base64'))
+    // A key that no longer opens the vault — the master password was changed,
+    // or the file was replaced — is dead weight that would fail every time.
+    if (!result.ok) disableBiometricUnlock()
+    return result
+  } catch (err) {
+    return { ok: false, error: `Could not read the stored key: ${(err as Error).message}` }
+  }
+}

--- a/src/main/services/biometrics.ts
+++ b/src/main/services/biometrics.ts
@@ -126,6 +126,24 @@ export function enableBiometricUnlock(): VaultResult {
   }
 }
 
+// Fails closed on any kind it has no prompt for.
+//
+// This was written inline as `if (kind === 'touch-id') await prompt(...)`, which
+// authenticated conditionally and then decrypted unconditionally — so adding a
+// windows-hello branch to biometricSupport() without also touching the unlock
+// path would have shipped a vault that opens with no prompt at all. Separated
+// out so the gate is a single expression that either authenticates or throws,
+// and so a test can prove it refuses an unknown kind.
+export async function authenticateFor(kind: BiometricKind, reason: string): Promise<void> {
+  switch (kind) {
+    case 'touch-id':
+      await systemPreferences.promptTouchID(reason)
+      return
+    default:
+      throw new Error(`No way to authenticate for "${kind}" on this platform.`)
+  }
+}
+
 export async function biometricUnlock(reason = 'unlock your ShellPilot vault'): Promise<VaultResult> {
   const stored = read()
   if (!stored) return { ok: false, error: 'Biometric unlock is not set up for this vault.' }
@@ -133,7 +151,7 @@ export async function biometricUnlock(reason = 'unlock your ShellPilot vault'): 
   if (!support.available) return { ok: false, error: support.reason ?? 'Biometric unlock is unavailable.' }
 
   try {
-    if (support.kind === 'touch-id') await systemPreferences.promptTouchID(reason)
+    await authenticateFor(support.kind, reason)
   } catch (err) {
     // A cancelled prompt is not a failure worth alarming about; the caller
     // falls back to the password field either way.

--- a/src/main/services/biometrics.ts
+++ b/src/main/services/biometrics.ts
@@ -25,6 +25,17 @@ import type { VaultResult } from '../../shared/vault'
 
 const FILE = join(app.getPath('userData'), 'shellpilot-vault-bio.json')
 
+// The session-scoped store: the wrapped key lives here, in main-process memory,
+// and dies with the process. This is KeePassXC's model, and it is the reason
+// this feature can be defended at all — an attacker who can read your files
+// gets nothing, because there is nothing on disk to read. Touch ID reopens the
+// vault while ShellPilot is running; the master password is typed once per
+// launch.
+//
+// The on-disk variant below survives a restart and is the weaker thing. It is a
+// separate, explicit opt-in rather than the default.
+let sessionKey: StoredKey | null = null
+
 export type BiometricKind = 'touch-id' | 'windows-hello' | 'none'
 
 export interface BiometricSupport {
@@ -88,11 +99,21 @@ function read(): StoredKey | null {
   }
 }
 
+export type BiometricScope = 'session' | 'persistent'
+
 export function biometricEnabled(): boolean {
-  return read() !== null
+  return sessionKey !== null || read() !== null
+}
+
+// Which of the two a vault is currently set up for, so the UI can say so rather
+// than showing one switch for two materially different things.
+export function biometricScope(): BiometricScope | null {
+  if (sessionKey) return 'session'
+  return read() ? 'persistent' : null
 }
 
 export function disableBiometricUnlock(): VaultResult {
+  sessionKey = null
   try {
     if (existsSync(FILE)) unlinkSync(FILE)
     return { ok: true }
@@ -101,10 +122,17 @@ export function disableBiometricUnlock(): VaultResult {
   }
 }
 
+// Locking the vault must also drop a session-scoped key, or "lock" would be a
+// lie: the whole point is that it does not outlive the unlocked state by more
+// than the app's own lifetime.
+export function forgetSessionKey(): void {
+  sessionKey = null
+}
+
 // Requires the vault to be unlocked already, because the key being stored is
 // the one currently in memory. There is no path here that turns a biometric
 // into access the caller did not already have.
-export function enableBiometricUnlock(): VaultResult {
+export function enableBiometricUnlock(scope: BiometricScope = 'session'): VaultResult {
   const support = biometricSupport()
   if (!support.available) return { ok: false, error: support.reason ?? 'Biometric unlock is unavailable.' }
   if (!vaultStatus().unlocked) return { ok: false, error: 'Unlock the vault first.' }
@@ -119,7 +147,14 @@ export function enableBiometricUnlock(): VaultResult {
       key: safeStorage.encryptString(exported.key.toString('base64')).toString('base64'),
       salt: exported.salt.toString('base64')
     }
-    writeFileSync(FILE, JSON.stringify(payload), { mode: 0o600 })
+    if (scope === 'session') {
+      sessionKey = payload
+      // Any previous on-disk key is stale the moment a session key exists, and
+      // leaving it behind would mean "session only" still had a file.
+      if (existsSync(FILE)) unlinkSync(FILE)
+    } else {
+      writeFileSync(FILE, JSON.stringify(payload), { mode: 0o600 })
+    }
     return { ok: true }
   } catch (err) {
     return { ok: false, error: `Could not store the key: ${(err as Error).message}` }
@@ -145,7 +180,7 @@ export async function authenticateFor(kind: BiometricKind, reason: string): Prom
 }
 
 export async function biometricUnlock(reason = 'unlock your ShellPilot vault'): Promise<VaultResult> {
-  const stored = read()
+  const stored = sessionKey ?? read()
   if (!stored) return { ok: false, error: 'Biometric unlock is not set up for this vault.' }
   const support = biometricSupport()
   if (!support.available) return { ok: false, error: support.reason ?? 'Biometric unlock is unavailable.' }

--- a/src/main/services/biometrics.ts
+++ b/src/main/services/biometrics.ts
@@ -53,14 +53,30 @@ export function biometricSupport(): BiometricSupport {
       : { available: false, kind: 'none', reason: 'No enrolled Touch ID fingerprint on this Mac.' }
   }
   if (process.platform === 'win32') {
-    // Windows Hello has no Electron API; it needs a native module binding
-    // Windows.Security.Credentials.UI. Deliberately not pulled in for this —
-    // a native dependency changes the build for all three platforms. The shape
-    // here is ready for it: a provider that can prompt, plus safeStorage
-    // (DPAPI) for the key, which is already what the other branches use.
-    return { available: false, kind: 'none', reason: 'Windows Hello is not supported yet.' }
+    // Electron exposes promptTouchID for macOS and nothing equivalent for
+    // Windows Hello — reaching Windows.Security.Credentials.UI needs a native
+    // addon, and there is no maintained npm package that provides one for
+    // Electron. Writing and shipping an unverifiable native module into the
+    // path that guards a credential store is a worse outcome than not offering
+    // the feature, so this reports honestly instead.
+    //
+    // Everything except the prompt is already platform-agnostic: safeStorage
+    // is DPAPI here, and biometricUnlock() only needs a provider that can
+    // authenticate the person. Adding one is a self-contained change to this
+    // function.
+    return {
+      available: false,
+      kind: 'none',
+      reason:
+        'Windows Hello needs a native module that Electron does not provide, so vault unlock is by ' +
+        'master password on Windows for now.'
+    }
   }
-  return { available: false, kind: 'none', reason: 'Biometric unlock is not supported on this platform.' }
+  return {
+    available: false,
+    kind: 'none',
+    reason: 'Biometric unlock is not available on this platform; unlock with your master password.'
+  }
 }
 
 function read(): StoredKey | null {

--- a/src/main/services/clientConfig.ts
+++ b/src/main/services/clientConfig.ts
@@ -44,13 +44,21 @@ export function httpUrl(port: number): string {
 
 // The one-liner for Claude Code, which speaks Streamable HTTP directly and so
 // needs no bridge process at all.
+//
+// Removes first, because `claude mcp add` refuses a name that already exists
+// ("MCP server shellpilot already exists in user config") rather than replacing
+// it. Every time after the first is a re-registration — a new session, or a
+// revoked one being replaced — so the plain add would have failed exactly when
+// it was needed most. `shellpilot claude` has always done remove-then-add for
+// this reason (src/cli/agents.ts); this just matches it.
 export function claudeCodeCommand(token: string, port: number): string {
-  return [
+  const add = [
     'claude mcp add -s user --transport http',
     SERVER_KEY,
     httpUrl(port),
     `--header "Authorization: Bearer ${token}"`
   ].join(' ')
+  return `claude mcp remove ${SERVER_KEY} -s user 2>/dev/null; ${add}`
 }
 
 export function claudeDesktopConfigPath(): string {

--- a/src/main/services/credentialResolver.ts
+++ b/src/main/services/credentialResolver.ts
@@ -23,9 +23,17 @@ export type CredentialSource = 'vault' | 'keychain' | 'inline' | 'none'
 // Why a connection has no usable credential, when it names a vault entry it
 // cannot read. Surfaced so the failure says "unlock the vault" rather than
 // ssh2's "All configured authentication methods failed".
+// A marker the renderer can recognise across the IPC boundary. Electron
+// serialises a rejected handler into a plain Error whose message is prefixed
+// with "Error invoking remote method ...", so the class and its name do not
+// survive the trip — a stable token inside the message does.
+export const VAULT_LOCKED = 'SHELLPILOT_VAULT_LOCKED'
+
 export class VaultLockedError extends Error {
   constructor() {
-    super('This server authenticates with a vault credential, and the vault is locked. Unlock it and try again.')
+    super(
+      `${VAULT_LOCKED}: this server authenticates with a vault credential, and the vault is locked.`
+    )
     this.name = 'VaultLockedError'
   }
 }

--- a/src/main/services/credentialResolver.ts
+++ b/src/main/services/credentialResolver.ts
@@ -140,3 +140,28 @@ export function knownSecretValuesForServer(serverId: string): string[] {
     return []
   }
 }
+
+
+// A database's stored credential, resolved the same way a server's is: keyed
+// by id in the OS keychain, read only in main, never returned to a caller.
+// The jump host's own credentials live in that same store under the server id.
+export function resolveDbSecrets<T extends { id: string; password?: string; uri?: string; ssh?: unknown }>(
+  cfg: T
+): T {
+  if (!cfg.password && !cfg.uri) {
+    const raw = getSecret(cfg.id)
+    if (raw) {
+      try {
+        const b = JSON.parse(raw) as { password?: string; uri?: string }
+        cfg.password = b.password
+        cfg.uri = b.uri
+      } catch {
+        cfg.password = raw // legacy plain-password secret
+      }
+    }
+  }
+  if (cfg.ssh) {
+    cfg.ssh = resolveChainSecrets({ ...(cfg.ssh as SshHop & { serverId?: string }) }) as T['ssh']
+  }
+  return cfg
+}

--- a/src/main/services/credentialResolver.ts
+++ b/src/main/services/credentialResolver.ts
@@ -1,13 +1,52 @@
 import { getSecret } from './secrets'
+import { vaultList, vaultStatus } from './vault'
 import type { SshHop } from '../../shared/ssh'
+import type { VaultEntry } from '../../shared/vault'
 
 export interface SecretBlob {
+  // A reference to a vault entry, which is where a credential belongs: one
+  // record, reusable across every server that authenticates with it, changed
+  // in one place when it rotates. The fields below remain for servers saved
+  // before the vault held credentials, and for anyone who would rather not
+  // keep one.
+  vaultEntryId?: string
   password?: string
   keyPath?: string
   passphrase?: string
   // Saved answer to a single keyboard-interactive prompt (a static second
   // password). One-time codes are never stored.
   kbAnswer?: string
+}
+
+export type CredentialSource = 'vault' | 'keychain' | 'inline' | 'none'
+
+// Why a connection has no usable credential, when it names a vault entry it
+// cannot read. Surfaced so the failure says "unlock the vault" rather than
+// ssh2's "All configured authentication methods failed".
+export class VaultLockedError extends Error {
+  constructor() {
+    super('This server authenticates with a vault credential, and the vault is locked. Unlock it and try again.')
+    this.name = 'VaultLockedError'
+  }
+}
+
+function vaultEntry(id: string): VaultEntry | null {
+  const status = vaultStatus()
+  if (!status.exists || !status.unlocked) throw new VaultLockedError()
+  return vaultList().entries?.find((e) => e.id === id) ?? null
+}
+
+// Copies a vault entry's material onto a connection. The entry is the single
+// source of truth: a key stored as material travels with an encrypted backup
+// and works on another machine, which a keyPath pointing at local plaintext
+// never did.
+function applyVaultEntry<T extends SshHop>(cfg: T, entry: VaultEntry): void {
+  if (entry.privateKey) {
+    cfg.privateKey = cfg.privateKey ?? entry.privateKey
+    cfg.passphrase = cfg.passphrase ?? (entry.password || undefined)
+  } else if (entry.password) {
+    cfg.password = cfg.password ?? entry.password
+  }
 }
 
 // Merges stored credentials (never exposed outside main) unless the caller
@@ -19,17 +58,44 @@ export function resolveSecrets<T extends SshHop & { serverId?: string }>(cfg: T)
   if (cfg.serverId && !cfg.password && !cfg.privateKey && !cfg.keyPath) {
     const raw = getSecret(cfg.serverId)
     if (raw) {
+      let blob: SecretBlob | null = null
       try {
-        const blob = JSON.parse(raw) as SecretBlob
+        blob = JSON.parse(raw) as SecretBlob
+      } catch {
+        /* a corrupt blob is the same as no stored credential */
+      }
+      if (blob) {
+        // A vault reference wins: it is the record the user maintains. A
+        // VaultLockedError deliberately propagates rather than falling through
+        // to the legacy fields — quietly authenticating with a stale copy of a
+        // credential the user has since changed in the vault is worse than a
+        // clear failure.
+        if (blob.vaultEntryId) {
+          const entry = vaultEntry(blob.vaultEntryId)
+          if (entry) applyVaultEntry(cfg, entry)
+        }
         cfg.password = cfg.password ?? blob.password
         cfg.keyPath = cfg.keyPath ?? blob.keyPath
         cfg.passphrase = cfg.passphrase ?? blob.passphrase
-      } catch {
-        /* ignore */
       }
     }
   }
   return cfg
+}
+
+// Which store a server's credential actually comes from, for the UI to show
+// without ever reading the credential itself.
+export function credentialSourceFor(serverId: string): { source: CredentialSource; vaultEntryId?: string } {
+  const raw = getSecret(serverId)
+  if (!raw) return { source: 'none' }
+  try {
+    const blob = JSON.parse(raw) as SecretBlob
+    if (blob.vaultEntryId) return { source: 'vault', vaultEntryId: blob.vaultEntryId }
+    if (blob.password || blob.keyPath || blob.passphrase) return { source: 'keychain' }
+    return { source: 'none' }
+  } catch {
+    return { source: 'none' }
+  }
 }
 
 // Every jump hop authenticates independently, so each one needs its own
@@ -50,7 +116,18 @@ export function knownSecretValuesForServer(serverId: string): string[] {
   if (!raw) return []
   try {
     const blob = JSON.parse(raw) as SecretBlob
-    return [blob.password, blob.passphrase, blob.kbAnswer].filter((v): v is string => !!v)
+    const values = [blob.password, blob.passphrase, blob.kbAnswer]
+    // A vault-backed credential must be redacted from agent-visible output for
+    // exactly the same reason a keychain one is.
+    if (blob.vaultEntryId) {
+      try {
+        const entry = vaultEntry(blob.vaultEntryId)
+        if (entry) values.push(entry.password, entry.privateKey)
+      } catch {
+        /* locked: nothing to redact, because nothing could be resolved either */
+      }
+    }
+    return values.filter((v): v is string => !!v)
   } catch {
     return []
   }

--- a/src/main/services/mcpDataCache.ts
+++ b/src/main/services/mcpDataCache.ts
@@ -7,6 +7,8 @@
 // store.ts's job.
 import { loadData } from './store'
 import type { SshAuth, SshHop } from '../../shared/ssh'
+import type { DbKind } from '../../shared/db'
+import type { TunnelKind } from '../../shared/tunnel'
 
 export type CachedHop = SshHop & { serverId?: string }
 
@@ -27,9 +29,37 @@ export interface CachedServer {
   route: CachedHop[]
 }
 
+export interface CachedDatabase {
+  id: string
+  workspaceId: string
+  name: string
+  kind: DbKind
+  host: string
+  port: number
+  username: string
+  database: string
+  ssl: boolean
+  uri: boolean
+  // Reached through this SSH server when set, exactly as an interactive
+  // connection would be.
+  sshServerId: string | null
+}
+
+export interface CachedTunnel {
+  id: string
+  workspaceId: string
+  name: string
+  kind: TunnelKind
+  serverId: string | null
+  listen: string
+  target: string
+}
+
 interface DataShape {
   workspaces?: unknown
   servers?: unknown
+  databases?: unknown
+  tunnels?: unknown
 }
 
 function isSshAuth(v: unknown): v is SshAuth {
@@ -88,6 +118,50 @@ function parseServers(raw: unknown): CachedServer[] {
     }))
 }
 
+function isDbKind(v: unknown): v is DbKind {
+  return v === 'postgres' || v === 'mysql' || v === 'mssql' || v === 'mongodb' || v === 'redis'
+}
+
+function isTunnelKind(v: unknown): v is TunnelKind {
+  return v === 'local' || v === 'remote' || v === 'socks'
+}
+
+function parseDatabases(raw: unknown): CachedDatabase[] {
+  if (!Array.isArray(raw)) return []
+  return raw
+    .filter(isRecord)
+    .filter((d) => typeof d.id === 'string' && typeof d.workspaceId === 'string')
+    .map((d) => ({
+      id: d.id as string,
+      workspaceId: d.workspaceId as string,
+      name: asString(d.name, asString(d.host)),
+      kind: isDbKind(d.kind) ? d.kind : 'postgres',
+      host: asString(d.host),
+      port: asNumber(d.port, 0),
+      username: asString(d.username),
+      database: asString(d.database),
+      ssl: d.ssl === true,
+      uri: d.uri === true,
+      sshServerId: typeof d.sshServerId === 'string' ? d.sshServerId : null
+    }))
+}
+
+function parseTunnels(raw: unknown): CachedTunnel[] {
+  if (!Array.isArray(raw)) return []
+  return raw
+    .filter(isRecord)
+    .filter((t) => typeof t.id === 'string' && typeof t.workspaceId === 'string')
+    .map((t) => ({
+      id: t.id as string,
+      workspaceId: t.workspaceId as string,
+      name: asString(t.name, t.id as string),
+      kind: isTunnelKind(t.kind) ? t.kind : 'local',
+      serverId: typeof t.serverId === 'string' ? t.serverId : null,
+      listen: asString(t.listen),
+      target: asString(t.target)
+    }))
+}
+
 // Builds the same shape the renderer sends over ssh:connect/sftp:connect for
 // this server, so the MCP bridge authenticates through the identical
 // jump-host chain and credential resolver as an interactive session. The
@@ -112,11 +186,37 @@ export function serverToSshConfig(
 
 let workspaces: CachedWorkspace[] = []
 let servers: CachedServer[] = []
+let databases: CachedDatabase[] = []
+let tunnels: CachedTunnel[] = []
 
 export function refreshMcpDataCache(data?: unknown): void {
   const raw = (data ?? loadData()) as DataShape | null
   workspaces = parseWorkspaces(raw?.workspaces)
   servers = parseServers(raw?.servers)
+  databases = parseDatabases(raw?.databases)
+  tunnels = parseTunnels(raw?.tunnels)
+}
+
+// Same scoping rule as servers: a session only ever sees what is inside the
+// workspace(s) it was granted, and never a credential.
+export function listCachedDatabases(workspaceId?: string | string[]): CachedDatabase[] {
+  if (!workspaceId) return databases
+  const ids = Array.isArray(workspaceId) ? workspaceId : [workspaceId]
+  return databases.filter((d) => ids.includes(d.workspaceId))
+}
+
+export function getCachedDatabase(id: string): CachedDatabase | null {
+  return databases.find((d) => d.id === id) ?? null
+}
+
+export function listCachedTunnels(workspaceId?: string | string[]): CachedTunnel[] {
+  if (!workspaceId) return tunnels
+  const ids = Array.isArray(workspaceId) ? workspaceId : [workspaceId]
+  return tunnels.filter((t) => ids.includes(t.workspaceId))
+}
+
+export function getCachedTunnel(id: string): CachedTunnel | null {
+  return tunnels.find((t) => t.id === id) ?? null
 }
 
 export function listCachedWorkspaces(): CachedWorkspace[] {

--- a/src/main/services/mcpServer.ts
+++ b/src/main/services/mcpServer.ts
@@ -8,13 +8,26 @@ import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
 
 import { authenticate, getSession, getMcpConfig, type AuthFailureReason } from './mcpAuth'
 import { startCliPairing, confirmCliPairing } from './cliPairing'
-import { listCachedServers, listCachedWorkspaces, getCachedWorkspace, getCachedServer, serverToSshConfig } from './mcpDataCache'
+import {
+  listCachedServers,
+  listCachedWorkspaces,
+  getCachedWorkspace,
+  getCachedServer,
+  listCachedDatabases,
+  listCachedTunnels,
+  serverToSshConfig,
+  type CachedDatabase,
+  type CachedTunnel
+} from './mcpDataCache'
 import { resolveServerByName, formatAmbiguity, type ServerMatch } from './serverResolver'
 import {
   resolveGroupId,
   evaluateCapability,
   evaluateCommand,
   evaluateFilePath,
+  evaluateDatabaseStatement,
+  evaluateTunnelOpen,
+  classifyStatement,
   mostRestrictive,
   type Decision
 } from './policyEngine'
@@ -22,8 +35,11 @@ import { getGroup, listAssignments } from './policyStore'
 import { requestApproval } from './approvals'
 import { recordAudit } from './auditLog'
 import { redactOutput } from './secretRedaction'
-import { knownSecretValuesForServer, resolveChainSecrets } from './credentialResolver'
+import { knownSecretValuesForServer, resolveChainSecrets, resolveDbSecrets } from './credentialResolver'
 import { sshExec } from './ssh'
+import { dbQuery } from './db'
+import { tunnelStart, tunnelStop, tunnelList } from './tunnel'
+import { parseEndpoint } from '../../shared/tunnel'
 import { createServerForAgent } from './agentServerCreate'
 import { sftpConnect, sftpList, sftpRead, sftpWrite, sftpDisconnect } from './sftp'
 import { metricsSample } from './metrics'
@@ -327,6 +343,66 @@ Permissions
 Not available
 - No SSH tunnels, port forwarding, database queries, or file upload/download beyond
   read_file/write_file. Do not attempt these through execute_command; say they are unsupported.`
+
+
+// A cached database record is the UI's shape; the driver wants a connect
+// config. Credentials are added separately by resolveDbSecrets, so this never
+// carries one.
+function databaseConfig(db: CachedDatabase): Parameters<typeof dbQuery>[0] {
+  const server = db.sshServerId ? getCachedServer(db.sshServerId) : null
+  return {
+    id: db.id,
+    kind: db.kind,
+    host: db.host,
+    port: db.port,
+    username: db.username,
+    database: db.database || undefined,
+    ssl: db.ssl,
+    ssh: server
+      ? {
+          serverId: server.id,
+          host: server.host,
+          port: server.port,
+          username: server.username,
+          auth: server.auth
+        }
+      : undefined
+  }
+}
+
+// Rows as a compact table. Capped, because an agent that asks for a million
+// rows should get a readable answer and a note, not a million rows.
+const MAX_ROWS = 200
+
+function formatQueryResult(r: Awaited<ReturnType<typeof dbQuery>>): string {
+  if (r.message) return r.message
+  if (r.json !== undefined) return JSON.stringify(r.json, null, 2).slice(0, 20000)
+  const cols = r.columns ?? []
+  const rows = r.rows ?? []
+  if (cols.length === 0 && rows.length === 0) return `OK${r.rowCount !== undefined ? ` (${r.rowCount} rows)` : ''}`
+  const shown = rows.slice(0, MAX_ROWS)
+  const head = cols.join(' | ')
+  const body = shown.map((row) => row.map((c) => (c === null ? 'NULL' : String(c))).join(' | ')).join('\n')
+  const note = rows.length > shown.length ? `\n… ${rows.length - shown.length} more rows not shown` : ''
+  return `${head}\n${'-'.repeat(Math.min(head.length, 80))}\n${body}${note}`
+}
+
+
+// The stored tunnel keeps "host:port" strings for a human to read; the service
+// wants them split. socks has no target, which parseEndpoint handles by
+// returning port 0 for an empty string.
+function tunnelConfigFor(t: CachedTunnel): Parameters<typeof tunnelStart>[1] {
+  const listen = parseEndpoint(t.listen)
+  const target = parseEndpoint(t.target)
+  return {
+    id: t.id,
+    kind: t.kind,
+    listenHost: listen.host,
+    listenPort: listen.port,
+    targetHost: target.host,
+    targetPort: target.port
+  }
+}
 
 function buildServer(): McpServer {
   const server = new McpServer({ name: 'shellpilot', version: '1.0.0' }, { instructions: INSTRUCTIONS })
@@ -687,6 +763,224 @@ function buildServer(): McpServer {
           `Uptime: ${Math.round(m.uptime / 3600)}h`
         ].join('\n')
       )
+    }
+  )
+
+  server.registerTool(
+    'list_databases',
+    {
+      title: 'List databases',
+      description:
+        'Lists the database connections this session may use, by friendly name. Names returned here ' +
+        'are the only valid databaseName values. Credentials are never included.',
+      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false }
+    },
+    async (extra) => {
+      const auth = authenticateExtra(extra)
+      if ('error' in auth) return errorText(AUTH_MESSAGES[auth.error])
+      const dbs = listCachedDatabases(auth.session.workspaces.map((w) => w.id))
+      if (dbs.length === 0) return text('No databases are available to this session.')
+      return text(
+        dbs
+          .map((d) => {
+            const ws = getCachedWorkspace(d.workspaceId)?.name ?? ''
+            const via = d.sshServerId ? ' (reached through an SSH server)' : ''
+            return `- ${d.name} — ${d.kind}${d.database ? `, database "${d.database}"` : ''}${via} [${ws}]`
+          })
+          .join('\n')
+      )
+    }
+  )
+
+  server.registerTool(
+    'query_database',
+    {
+      title: 'Run a database query',
+      description:
+        'Runs a statement against a saved database connection and returns the rows. Reads are governed ' +
+        'by the databaseAccess capability; anything that modifies data or schema is additionally bounded ' +
+        'by writeFiles and always requires user approval, whatever the access group says. Address the ' +
+        'database by the friendly name from list_databases — connection details and credentials are ' +
+        'resolved by ShellPilot and never visible here.',
+      inputSchema: {
+        databaseName: z.string().describe('Friendly name exactly as returned by list_databases'),
+        statement: z
+          .string()
+          .describe('A single statement. SQL for relational engines, shell syntax for MongoDB and Redis.')
+      },
+      annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false, openWorldHint: true }
+    },
+    async ({ databaseName, statement }, extra) => {
+      const auth = authenticateExtra(extra)
+      if ('error' in auth) return errorText(AUTH_MESSAGES[auth.error])
+      const { session } = auth
+
+      const wanted = databaseName.trim().toLowerCase()
+      const matches = listCachedDatabases(session.workspaces.map((w) => w.id)).filter(
+        (d) => d.name.toLowerCase() === wanted
+      )
+      if (matches.length === 0) return errorText(`No database named "${databaseName}" is available to this session.`)
+      if (matches.length > 1) {
+        return errorText(`"${databaseName}" matches more than one database in this session's workspaces.`)
+      }
+      const db = matches[0]
+      const workspace = getCachedWorkspace(db.workspaceId)
+
+      const scopeGroupId = resolveGroupId(listAssignments(), '', db.workspaceId)
+      const scopeGroup = scopeGroupId ? getGroup(scopeGroupId) : null
+      const check = withCeiling(
+        evaluateDatabaseStatement(scopeGroup, statement),
+        sessionGroupFor(session) ? evaluateDatabaseStatement(sessionGroupFor(session), statement) : null,
+        `the workspace's access group ("${scopeGroup?.name ?? 'none'}")`
+      )
+
+      const ctx: AuditContext = {
+        session,
+        workspaceId: db.workspaceId,
+        workspaceName: workspace?.name ?? '',
+        serverId: db.id,
+        serverName: db.name,
+        // The statement is the action, and it is persisted to the audit log —
+        // which is exactly why a credential must never be inside one.
+        action: statement,
+        capability: 'databaseAccess'
+      }
+
+      const gated = await gate(ctx, check, classifyStatement(statement) === 'read' ? 'low' : 'high')
+      if (!gated.ok) return gated.result
+
+      const approval = check.decision === 'ask' ? 'approved' : 'not-required'
+      try {
+        const result = await dbQuery(resolveDbSecrets(databaseConfig(db)), statement)
+        if (!result.ok) {
+          recordAudit({ ...auditBase(ctx), approval, result: 'error', error: result.error ?? 'query failed' })
+          return errorText(result.error ?? 'The query failed.')
+        }
+        auditSuccess(ctx, approval)
+        return text(formatQueryResult(result))
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        recordAudit({ ...auditBase(ctx), approval, result: 'error', error: message })
+        return errorText(message)
+      }
+    }
+  )
+
+  server.registerTool(
+    'list_tunnels',
+    {
+      title: 'List tunnels',
+      description:
+        'Lists the SSH tunnels configured in this session\'s workspaces, with whether each is currently ' +
+        'running. Names returned here are the only valid tunnelName values.',
+      annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false }
+    },
+    async (extra) => {
+      const auth = authenticateExtra(extra)
+      if ('error' in auth) return errorText(AUTH_MESSAGES[auth.error])
+      const tunnels = listCachedTunnels(auth.session.workspaces.map((w) => w.id))
+      if (tunnels.length === 0) return text('No tunnels are configured in this session\'s workspaces.')
+      const live = new Map(tunnelList().map((t) => [t.id, t]))
+      return text(
+        tunnels
+          .map((t) => {
+            const status = live.get(t.id)
+            const state = status ? status.state : 'stopped'
+            return `- ${t.name} — ${t.kind}, ${t.listen} -> ${t.target} [${state}]`
+          })
+          .join('\n')
+      )
+    }
+  )
+
+  server.registerTool(
+    'set_tunnel',
+    {
+      title: 'Start or stop a tunnel',
+      description:
+        'Starts or stops a tunnel that is already configured in ShellPilot. Requires the sshTunnel ' +
+        'capability, and starting one always requires user approval whatever the access group says, ' +
+        'because it binds a listening port on the user\'s own machine. This cannot create a tunnel or ' +
+        'change where one points — only run one the user has already defined.',
+      inputSchema: {
+        tunnelName: z.string().describe('Friendly name exactly as returned by list_tunnels'),
+        running: z.boolean().describe('true to start the tunnel, false to stop it')
+      },
+      annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false }
+    },
+    async ({ tunnelName, running }, extra) => {
+      const auth = authenticateExtra(extra)
+      if ('error' in auth) return errorText(AUTH_MESSAGES[auth.error])
+      const { session } = auth
+
+      const wanted = tunnelName.trim().toLowerCase()
+      const matches = listCachedTunnels(session.workspaces.map((w) => w.id)).filter(
+        (t) => t.name.toLowerCase() === wanted
+      )
+      if (matches.length === 0) return errorText(`No tunnel named "${tunnelName}" is available to this session.`)
+      if (matches.length > 1) return errorText(`"${tunnelName}" matches more than one tunnel.`)
+      const tunnel = matches[0]
+      const workspace = getCachedWorkspace(tunnel.workspaceId)
+
+      const scopeGroupId = resolveGroupId(listAssignments(), '', tunnel.workspaceId)
+      const scopeGroup = scopeGroupId ? getGroup(scopeGroupId) : null
+      const sessionGroup = sessionGroupFor(session)
+
+      // Stopping is bounded by the same capability but is not the dangerous
+      // direction, so it does not force an approval the way starting does.
+      const evaluate = (g: AccessGroup | null): Decision =>
+        running
+          ? evaluateTunnelOpen(g)
+          : g
+            ? evaluateCapability(g, 'sshTunnel')
+            : { decision: 'deny', reason: 'No AI access is assigned to this workspace.' }
+
+      const check = withCeiling(
+        evaluate(scopeGroup),
+        sessionGroup ? evaluate(sessionGroup) : null,
+        `the workspace's access group ("${scopeGroup?.name ?? 'none'}")`
+      )
+
+      const ctx: AuditContext = {
+        session,
+        workspaceId: tunnel.workspaceId,
+        workspaceName: workspace?.name ?? '',
+        serverId: tunnel.id,
+        serverName: tunnel.name,
+        action: `${running ? 'Start' : 'Stop'} tunnel "${tunnel.name}" (${tunnel.listen} -> ${tunnel.target})`,
+        capability: 'sshTunnel'
+      }
+
+      const gated = await gate(ctx, check, running ? 'high' : 'low')
+      if (!gated.ok) return gated.result
+      const approval = check.decision === 'ask' ? 'approved' : 'not-required'
+
+      try {
+        if (!running) {
+          await tunnelStop(tunnel.id)
+          auditSuccess(ctx, approval)
+          return text(`Stopped "${tunnel.name}".`)
+        }
+        const server = tunnel.serverId ? getCachedServer(tunnel.serverId) : null
+        if (!server) return errorText(`"${tunnel.name}" has no SSH server configured to carry it.`)
+        // No renderer asked for this one, so there is nowhere to push status
+        // events; the tunnel manager reads live state when it next renders.
+        const result = await tunnelStart(
+          null,
+          tunnelConfigFor(tunnel),
+          resolveChainSecrets(serverToSshConfig(server))
+        )
+        if (!result.ok) {
+          recordAudit({ ...auditBase(ctx), approval, result: 'error', error: result.error ?? 'failed to start' })
+          return errorText(result.error ?? 'The tunnel failed to start.')
+        }
+        auditSuccess(ctx, approval)
+        return text(`Started "${tunnel.name}" on port ${result.listenPort ?? tunnel.listen}.`)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        recordAudit({ ...auditBase(ctx), approval, result: 'error', error: message })
+        return errorText(message)
+      }
     }
   )
 

--- a/src/main/services/mcpServer.ts
+++ b/src/main/services/mcpServer.ts
@@ -38,12 +38,24 @@ function errorText(s: string): CallToolResult {
   return { content: [{ type: 'text', text: s }], isError: true }
 }
 
+// Creating a session in ShellPilot does not reconfigure the client: the token
+// lives in the client's own config file, so a new session leaves the old,
+// dead token exactly where it was. "Ask the user to create a new one" was
+// therefore advice that does not work on its own — it is the half of the fix
+// that is easy to do and does nothing, and following it produces the identical
+// error. Say the other half.
+const RE_REGISTER =
+  'Creating a session in ShellPilot is not enough on its own — the token lives in this ' +
+  "client's own configuration, so it must be pointed at the new one. In ShellPilot, use " +
+  'AI & MCP > Overview > Connect, which issues a session and gives back the exact command or ' +
+  'config entry to apply, then reconnect this client.'
+
 const AUTH_MESSAGES: Record<AuthFailureReason, string> = {
-  'ai-disabled': 'AI & MCP access is currently disabled in ShellPilot.',
+  'ai-disabled': 'AI & MCP access is currently disabled in ShellPilot. Enable it under AI & MCP > Security.',
   'missing-token': 'No bearer token was supplied. Configure this agent with the token from AI & MCP > Agents.',
-  'invalid-token': 'This token is not recognized. It may have been regenerated — reconnect with the current one.',
-  revoked: 'This session has been revoked from ShellPilot. Ask the user to create a new one.',
-  expired: 'This session has expired. Ask the user to create a new one.'
+  'invalid-token': `This token is not recognized by ShellPilot. ${RE_REGISTER}`,
+  revoked: `This session has been revoked in ShellPilot. ${RE_REGISTER}`,
+  expired: `This session has expired. ${RE_REGISTER}`
 }
 
 interface RequestInfoLike {

--- a/src/main/services/metrics.ts
+++ b/src/main/services/metrics.ts
@@ -1,6 +1,6 @@
 import type { Client } from 'ssh2'
 import { acquire, release, type PooledConnection } from './ssh'
-import type { HostMetrics, MetricsResult, SshConnectConfig } from '../../shared/ssh'
+import type { HostMetrics, MetricsResult, PortListener, ServiceUnit, SshConnectConfig } from '../../shared/ssh'
 
 interface Conn {
   conn: PooledConnection
@@ -59,8 +59,26 @@ const script = (withSleep: boolean): string => [
   'echo __KERN__',
   'uname -r',
   'echo __CORES__',
-  'nproc'
+  'nproc',
+  // Both of these are absent on plenty of hosts — a container without systemd,
+  // a box with neither ss nor netstat — so each is guarded and simply produces
+  // an empty section rather than an error that would spoil the whole sample.
+  // The marker line records which probe ran, because it changes how the output
+  // parses and what the UI can honestly claim.
+  'echo __SVC__',
+  "command -v systemctl >/dev/null 2>&1 && systemctl list-units --type=service --state=running,failed --no-pager --no-legend --plain 2>/dev/null | head -" + String(MAX_SERVICES),
+  'echo __PORTS__',
+  // ss is preferred: it is present on anything modern, and netstat is
+  // deprecated and absent by default on many distributions now.
+  "if command -v ss >/dev/null 2>&1; then echo 'src:ss'; ss -lntupH 2>/dev/null | head -" + String(MAX_LISTENERS) +
+    "; elif command -v netstat >/dev/null 2>&1; then echo 'src:netstat'; netstat -lntup 2>/dev/null | head -" + String(MAX_LISTENERS) + '; fi'
 ].join('; ')
+
+// A busy host can run hundreds of units and listen on as many sockets. These
+// are polled continuously, so the sample is capped rather than allowed to grow
+// without limit — the UI says when it truncated.
+const MAX_SERVICES = 80
+const MAX_LISTENERS = 120
 
 const CMD = script(false)
 const CMD_FIRST = script(true)
@@ -71,6 +89,89 @@ function section(text: string, name: string): string[] {
   const rest = parts[1]
   const end = rest.search(/__[A-Z]+__/)
   return (end === -1 ? rest : rest.slice(0, end)).trim().split('\n').filter(Boolean)
+}
+
+// `systemctl list-units --plain --no-legend` gives:
+//   nginx.service loaded active running A high performance web server
+// Bullet-prefixed lines (● for failed) survive --plain on some versions, so
+// the leading marker is stripped rather than assumed absent.
+export function parseServices(lines: string[]): ServiceUnit[] {
+  const out: ServiceUnit[] = []
+  for (const raw of lines) {
+    const line = raw.replace(/^[●*✓✗\s]+/, '').trim()
+    if (!line) continue
+    const parts = line.split(/\s+/)
+    if (parts.length < 4) continue
+    const [name, , active, sub, ...rest] = parts
+    if (!name.endsWith('.service')) continue
+    out.push({ name: name.replace(/\.service$/, ''), active, sub, description: rest.join(' ') })
+  }
+  return out
+}
+
+// Splits "0.0.0.0:22", "[::]:22" and "*:22" into address and port. Taking the
+// last colon rather than the first is what makes IPv6 work.
+export function splitEndpoint(text: string): { address: string; port: number } | null {
+  const i = text.lastIndexOf(':')
+  if (i === -1) return null
+  const port = Number(text.slice(i + 1))
+  if (!Number.isFinite(port) || port <= 0) return null
+  const address = text.slice(0, i).replace(/^\[|\]$/g, '') || '*'
+  // 0.0.0.0, :: and * all mean "every interface". Reported as one thing so a
+  // dual-stack listener reads as the single service it is, rather than as two
+  // rows that differ only in address family.
+  return { address: address === '0.0.0.0' || address === '::' ? '*' : address, port }
+}
+
+// users:(("sshd",pid=1234,fd=3))  →  { process: 'sshd', pid: 1234 }
+export function parseSsUsers(text: string): { process?: string; pid?: number } {
+  const m = /users:\(\("([^"]+)",pid=(\d+)/.exec(text)
+  return m ? { process: m[1], pid: Number(m[2]) } : {}
+}
+
+export function parseListeners(lines: string[]): { listeners: PortListener[]; source: 'ss' | 'netstat' | null } {
+  const first = lines[0]?.trim()
+  const source = first === 'src:ss' ? 'ss' : first === 'src:netstat' ? 'netstat' : null
+  if (!source) return { listeners: [], source: null }
+
+  const out: PortListener[] = []
+  const seen = new Set<string>()
+  for (const line of lines.slice(1)) {
+    const parts = line.trim().split(/\s+/)
+    if (parts.length < 4) continue
+
+    let proto: string
+    let endpoint: string
+    let owner: { process?: string; pid?: number }
+
+    if (source === 'ss') {
+      // tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:(("sshd",pid=1,fd=3))
+      proto = parts[0]
+      // udp rows have no LISTEN state, so the local address is found by
+      // position from the end of the fixed columns rather than a fixed index.
+      endpoint = parts[4] ?? ''
+      owner = parseSsUsers(line)
+    } else {
+      // tcp 0 0 0.0.0.0:22 0.0.0.0:* LISTEN 1234/sshd
+      proto = parts[0]
+      endpoint = parts[3] ?? ''
+      const prog = parts.find((p) => /^\d+\/\S+$/.test(p))
+      const m = prog ? /^(\d+)\/(.+)$/.exec(prog) : null
+      owner = m ? { pid: Number(m[1]), process: m[2] } : {}
+      if (!/LISTEN/.test(line) && !proto.startsWith('udp')) continue
+    }
+
+    const split = splitEndpoint(endpoint)
+    if (!split) continue
+    // With wildcards normalised, the v4 and v6 rows of a dual-stack listener
+    // collapse to one — which is what a reader wants to see.
+    const dedupe = `${proto}|${split.address}|${split.port}`
+    if (seen.has(dedupe)) continue
+    seen.add(dedupe)
+    out.push({ proto: proto.replace(/6$/, ''), ...split, ...owner })
+  }
+  out.sort((a, b) => a.port - b.port || a.proto.localeCompare(b.proto))
+  return { listeners: out, source }
 }
 
 interface CpuSnap {
@@ -129,6 +230,15 @@ function parse(text: string, prev: CpuSnap | null): { data: HostMetrics; snap: C
   const kernel = section(text, 'KERN')[0] ?? ''
   const cores = parseInt(section(text, 'CORES')[0] ?? '1') || 1
 
+  const svcLines = section(text, 'SVC')
+  // The guard in the script means a host without systemd emits nothing here at
+  // all, which is indistinguishable from systemd running no matching units —
+  // so presence of the section header is not enough. A running host always has
+  // at least one running unit, so an empty section on a systemd host is
+  // vanishingly unlikely; treat lines-present as the signal and say so.
+  const hasSystemd = svcLines.length > 0
+  const { listeners, source: listenerSource } = parseListeners(section(text, 'PORTS'))
+
   const data: HostMetrics = {
     cpu,
     memPct: memTotal ? (memUsed / memTotal) * 100 : 0,
@@ -142,7 +252,12 @@ function parse(text: string, prev: CpuSnap | null): { data: HostMetrics; snap: C
     uptime,
     hostname,
     kernel,
-    cores
+    cores,
+    // An absent section means the tool is not on the host; an empty one means
+    // it ran and found nothing. Only the former becomes null.
+    services: svcLines.length > 0 ? parseServices(svcLines) : hasSystemd ? [] : null,
+    listeners: listenerSource ? listeners : null,
+    listenerSource
   }
   return { data, snap: latest }
 }

--- a/src/main/services/policyEngine.ts
+++ b/src/main/services/policyEngine.ts
@@ -329,3 +329,107 @@ export function evaluateFilePath(
   }
   return blanket
 }
+
+
+// Database statements, classified the way commands already are.
+//
+// databaseAccess defaults to ALLOW in every built-in group, because until now
+// nothing was gated on it. Shipping a query tool that simply honoured that
+// would hand a Full Access agent a silent DROP TABLE, so this follows the rule
+// the codebase already applies to sudo: the dangerous form is never granted
+// silently, whatever the group says.
+//
+// Reads are governed by databaseAccess alone. Anything that writes is also
+// bounded by writeFiles — a group whose whole point is that it cannot change
+// anything should not be able to change a row either — and can never resolve
+// better than ASK.
+export type StatementKind = 'read' | 'mutating' | 'destructive'
+
+const DESTRUCTIVE = /^(drop|truncate|alter|create|rename|grant|revoke|flushall|flushdb|shutdown)\b/
+const MUTATING =
+  /^(insert|update|delete|replace|merge|upsert|copy|load|call|do|set|del|unlink|expire|rpush|lpush|sadd|hset|incr|decr|append|getset|move|migrate|restore|persist)\b/
+const READ = /^(select|show|explain|describe|desc|with|values|table|analyze|get|mget|keys|scan|type|ttl|exists|llen|lrange|smembers|hget|hgetall|zrange|info|dbsize|find|aggregate|count|distinct|list)\b/
+
+// Strips leading comments and parenthesised prefixes so the verb is the first
+// thing tested, and splits on ; so a read cannot smuggle a write behind one.
+function statements(sql: string): string[] {
+  return sql
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/--[^\n]*/g, ' ')
+    .split(';')
+    .map((s) => s.trim().replace(/^\(+/, '').trim().toLowerCase())
+    .filter(Boolean)
+}
+
+// Mongo shell statements lead with the collection, not the verb —
+// db.users.find({}) — so the leading-verb tests never see the operation.
+const MONGO = /^db\.(?:getcollection\(['"]?[\w.$-]+['"]?\)|[\w.$-]+)\.(\w+)\s*\(/
+const MONGO_READ = new Set([
+  'find', 'findone', 'aggregate', 'count', 'countdocuments', 'estimateddocumentcount',
+  'distinct', 'getindexes', 'stats', 'explain', 'watch'
+])
+const MONGO_DESTRUCTIVE = new Set(['drop', 'dropindex', 'dropindexes', 'renamecollection'])
+
+function classifyMongo(s: string): StatementKind | null {
+  if (/^db\.dropdatabase\s*\(/.test(s)) return 'destructive'
+  const m = MONGO.exec(s)
+  if (!m) return null
+  const method = m[1].toLowerCase()
+  if (MONGO_DESTRUCTIVE.has(method)) return 'destructive'
+  return MONGO_READ.has(method) ? 'read' : 'mutating'
+}
+
+export function classifyStatement(sql: string): StatementKind {
+  let worst: StatementKind = 'read'
+  for (const s of statements(sql)) {
+    const mongo = classifyMongo(s)
+    if (mongo === 'destructive') return 'destructive'
+    if (mongo === 'mutating') {
+      worst = 'mutating'
+      continue
+    }
+    if (mongo === 'read') continue
+
+    if (DESTRUCTIVE.test(s)) return 'destructive'
+    if (MUTATING.test(s)) worst = 'mutating'
+    // An unrecognised verb is treated as mutating rather than read. There are
+    // far too many dialects to enumerate, and guessing "harmless" is the
+    // expensive direction to be wrong in.
+    else if (!READ.test(s)) worst = worst === 'read' ? 'mutating' : worst
+  }
+  return worst
+}
+
+export function evaluateDatabaseStatement(group: AccessGroup | null, sql: string): Decision {
+  if (!group) return { decision: 'deny', reason: 'No AI access is assigned to this workspace.' }
+
+  const access = evaluateCapability(group, 'databaseAccess')
+  if (access.decision === 'deny') return { decision: 'deny', reason: 'Database access is denied for this access group.' }
+
+  const kind = classifyStatement(sql)
+  if (kind === 'read') return access
+
+  const write = evaluateCapability(group, 'writeFiles')
+  if (write.decision === 'deny') {
+    return {
+      decision: 'deny',
+      reason: `This statement ${kind === 'destructive' ? 'changes schema or permissions' : 'modifies data'}, and this access group cannot write.`
+    }
+  }
+  const combined = mostRestrictive(access, write)
+  // Never silently: a write or a DDL always surfaces an approval prompt.
+  return combined.decision === 'allow'
+    ? { decision: 'ask', reason: `Statements that ${kind === 'destructive' ? 'change schema or permissions' : 'modify data'} always require approval.` }
+    : combined
+}
+
+// Opening a tunnel binds a listener on the user's own machine, so it gets the
+// same treatment: bounded by sshTunnel and never granted silently.
+export function evaluateTunnelOpen(group: AccessGroup | null): Decision {
+  if (!group) return { decision: 'deny', reason: 'No AI access is assigned to this workspace.' }
+  const tunnel = evaluateCapability(group, 'sshTunnel')
+  if (tunnel.decision === 'deny') return { decision: 'deny', reason: 'SSH tunnels are denied for this access group.' }
+  return tunnel.decision === 'allow'
+    ? { decision: 'ask', reason: 'Opening a tunnel binds a port on your machine and always requires approval.' }
+    : tunnel
+}

--- a/src/main/services/tunnel.ts
+++ b/src/main/services/tunnel.ts
@@ -18,13 +18,16 @@ interface Active {
   error?: string
   connections: number
   listenPort?: number
-  wc: WebContents
+  wc: WebContents | null
 }
 
 const tunnels = new Map<string, Active>()
 
+// A tunnel started by an AI agent has no renderer that asked for it, so there
+// is nowhere to push status to. That is not a reason to refuse to start one —
+// the tunnel manager reads live state from tunnelList() when it next renders.
 function emit(t: Active): void {
-  if (t.wc.isDestroyed()) return
+  if (!t.wc || t.wc.isDestroyed()) return
   const status: TunnelStatus = {
     id: t.cfg.id,
     state: t.state,
@@ -191,7 +194,7 @@ async function handleSocks(t: Active, client: Client, socket: net.Socket): Promi
 // ---------------------------------------------------------------- lifecycle
 
 export async function tunnelStart(
-  wc: WebContents,
+  wc: WebContents | null,
   cfg: TunnelConfig,
   ssh: TunnelSshConfig
 ): Promise<TunnelResult> {

--- a/src/main/services/vault.ts
+++ b/src/main/services/vault.ts
@@ -105,6 +105,33 @@ export async function vaultUnlock(password: string): Promise<VaultResult> {
   }
 }
 
+// The derived key, for biometric unlock to hold on the user's behalf. Only
+// ever readable while the vault is already unlocked — this cannot be used to
+// obtain a key the caller did not already have — and never leaves the main
+// process. Returned as a copy so a caller cannot zero the live key.
+export function vaultExportKey(): { key: Buffer; salt: Buffer } | null {
+  if (!key || !salt) return null
+  return { key: Buffer.from(key), salt: Buffer.from(salt) }
+}
+
+// Unlock with a previously derived key instead of a password. The GCM tag is
+// still what decides: a key that does not decrypt the file fails exactly as a
+// wrong password does, so a corrupted or stale stored key cannot half-open a
+// vault.
+export function vaultUnlockWithKey(k: Buffer, s: Buffer): VaultResult {
+  const file = readFile()
+  if (!file) return { ok: false, error: 'No vault exists yet.' }
+  try {
+    const entries = decrypt(file, k)
+    key = Buffer.from(k)
+    salt = Buffer.from(s)
+    cache = entries
+    return { ok: true }
+  } catch {
+    return { ok: false, error: 'The stored key no longer opens this vault.' }
+  }
+}
+
 export function vaultLock(): VaultResult {
   key?.fill(0)
   key = null

--- a/src/main/services/vault.ts
+++ b/src/main/services/vault.ts
@@ -6,8 +6,14 @@ import type { VaultEntry, VaultListResult, VaultResult, VaultStatus } from '../.
 
 // The vault is encrypted with AES-256-GCM under a key derived from the user's
 // master password via scrypt. The password is never stored — a wrong password
-// simply fails the GCM authentication tag on decrypt. The plaintext exists only
-// in main-process memory while the vault is unlocked.
+// simply fails the GCM authentication tag on decrypt.
+//
+// The KEY exists only in main-process memory while the vault is unlocked. The
+// decrypted ENTRIES do not: vault:list ships them to the renderer, where they
+// live in the Zustand store for as long as the vault is open. That is a
+// deliberate consequence of showing them in a UI, but it means renderer-side
+// script injection reaches vault plaintext, and the threat model has to say so
+// rather than claim main-process confinement it does not have.
 
 const FILE = join(app.getPath('userData'), 'shellpilot-vault.json')
 const TMP = `${FILE}.tmp`

--- a/src/main/services/vault.ts
+++ b/src/main/services/vault.ts
@@ -19,7 +19,23 @@ const FILE = join(app.getPath('userData'), 'shellpilot-vault.json')
 const TMP = `${FILE}.tmp`
 
 // 128 * N * r = 32 MiB of work per derivation; maxmem must exceed that.
-const KDF = { N: 32768, r: 8, p: 1, keylen: 32, maxmem: 96 * 1024 * 1024 }
+//
+// p=3 rather than 1: OWASP's password-storage guidance lists N=2^15 as adequate
+// only at p=3, so the previous p=1 was running at about a third of the intended
+// work factor. That matters more for an attacker holding a copy of the vault
+// file than any of the unlock UI does.
+const KDF = { N: 32768, r: 8, p: 3, keylen: 32, maxmem: 96 * 1024 * 1024 }
+
+// What vaults written before the parameters were raised used. A file records
+// the parameters it was written with, so an existing vault still opens; it is
+// re-encrypted at the current settings the next time it is saved.
+const LEGACY_KDF = { N: 32768, r: 8, p: 1, keylen: 32, maxmem: 96 * 1024 * 1024 }
+
+interface KdfParams {
+  N: number
+  r: number
+  p: number
+}
 
 interface VaultFile {
   version: 1
@@ -27,18 +43,28 @@ interface VaultFile {
   iv: string
   tag: string
   data: string
+  // Absent on files written before this existed, which means LEGACY_KDF.
+  kdf?: KdfParams
 }
 
 let key: Buffer | null = null
 let salt: Buffer | null = null
 let cache: VaultEntry[] | null = null
 
-function derive(password: string, s: Buffer): Promise<Buffer> {
+function derive(password: string, s: Buffer, params: KdfParams = KDF): Promise<Buffer> {
   return new Promise((resolve, reject) => {
-    scrypt(password, s, KDF.keylen, { N: KDF.N, r: KDF.r, p: KDF.p, maxmem: KDF.maxmem }, (err, dk) =>
+    scrypt(password, s, KDF.keylen, { N: params.N, r: params.r, p: params.p, maxmem: KDF.maxmem }, (err, dk) =>
       err ? reject(err) : resolve(dk as Buffer)
     )
   })
+}
+
+function kdfOf(file: VaultFile): KdfParams {
+  return file.kdf ?? LEGACY_KDF
+}
+
+function isCurrentKdf(params: KdfParams): boolean {
+  return params.N === KDF.N && params.r === KDF.r && params.p === KDF.p
 }
 
 function readFile(): VaultFile | null {
@@ -58,6 +84,7 @@ function writeEncrypted(entries: VaultEntry[], k: Buffer, s: Buffer): void {
   const file: VaultFile = {
     version: 1,
     salt: s.toString('base64'),
+    kdf: { N: KDF.N, r: KDF.r, p: KDF.p },
     iv: iv.toString('base64'),
     tag: cipher.getAuthTag().toString('base64'),
     data: data.toString('base64')
@@ -98,10 +125,30 @@ export async function vaultUnlock(password: string): Promise<VaultResult> {
   if (!file) return { ok: false, error: 'No vault has been created yet.' }
   try {
     const s = Buffer.from(file.salt, 'base64')
-    const k = await derive(password, s)
+    const stored = kdfOf(file)
+    const k = await derive(password, s, stored)
     cache = decrypt(file, k) // throws if the password is wrong
+
+    // Upgrade a vault written at the old work factor, now that the password is
+    // in hand and known correct — the only moment it can be re-derived. Silent
+    // because the user has nothing to decide, and best-effort because failing
+    // to upgrade is not a reason to refuse an unlock that already succeeded.
+    if (!isCurrentKdf(stored)) {
+      try {
+        const upgraded = await derive(password, s, KDF)
+        writeEncrypted(cache, upgraded, s)
+        key = upgraded
+        salt = s
+        touchVaultActivity()
+        return { ok: true }
+      } catch {
+        /* keep the vault open on the parameters it already had */
+      }
+    }
+
     key = k
     salt = s
+    touchVaultActivity()
     return { ok: true }
   } catch {
     key = null
@@ -132,13 +179,44 @@ export function vaultUnlockWithKey(k: Buffer, s: Buffer): VaultResult {
     key = Buffer.from(k)
     salt = Buffer.from(s)
     cache = entries
+    touchVaultActivity()
     return { ok: true }
   } catch {
     return { ok: false, error: 'The stored key no longer opens this vault.' }
   }
 }
 
+// Idle auto-lock.
+//
+// A vault that never locks itself makes every other protection here optional:
+// the key sits in memory and the decrypted entries sit in the renderer for as
+// long as the app is open, which on a workstation is days. The timer is reset
+// by vault activity, not by general app use — reading your own entries is what
+// counts as using the vault.
+let idleTimer: ReturnType<typeof setTimeout> | null = null
+let idleMinutes = 15
+let onAutoLock: (() => void) | null = null
+
+export function setVaultAutoLock(minutes: number, onLock?: () => void): void {
+  idleMinutes = minutes
+  if (onLock) onAutoLock = onLock
+  touchVaultActivity()
+}
+
+export function touchVaultActivity(): void {
+  if (idleTimer) clearTimeout(idleTimer)
+  idleTimer = null
+  // 0 disables it, for anyone who would rather decide for themselves.
+  if (idleMinutes <= 0 || !key) return
+  idleTimer = setTimeout(() => {
+    vaultLock()
+    onAutoLock?.()
+  }, idleMinutes * 60_000)
+}
+
 export function vaultLock(): VaultResult {
+  if (idleTimer) clearTimeout(idleTimer)
+  idleTimer = null
   key?.fill(0)
   key = null
   salt = null
@@ -147,12 +225,14 @@ export function vaultLock(): VaultResult {
 }
 
 export function vaultList(): VaultListResult {
+  touchVaultActivity()
   if (!key || !cache) return { ok: false, error: 'Vault is locked.' }
   return { ok: true, entries: cache }
 }
 
 export function vaultSave(entries: VaultEntry[]): VaultResult {
   if (!key || !salt) return { ok: false, error: 'Vault is locked.' }
+  touchVaultActivity()
   try {
     writeEncrypted(entries, key, salt)
     cache = entries

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -225,6 +225,11 @@ const api = {
     bioEnable: (scope: 'session' | 'persistent' = 'session'): Promise<VaultResult> =>
       ipcRenderer.invoke('vault:bio-enable', scope),
     bioScope: (): Promise<'session' | 'persistent' | null> => ipcRenderer.invoke('vault:bio-scope'),
+    onAutoLocked: (cb: () => void): (() => void) => {
+      const h = (): void => cb()
+      ipcRenderer.on('vault:auto-locked', h)
+      return () => ipcRenderer.removeListener('vault:auto-locked', h)
+    },
     bioDisable: (): Promise<VaultResult> => ipcRenderer.invoke('vault:bio-disable'),
     bioUnlock: (): Promise<VaultResult> => ipcRenderer.invoke('vault:bio-unlock')
   },

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -222,7 +222,9 @@ const api = {
     bioSupport: (): Promise<{ available: boolean; kind: string; reason?: string }> =>
       ipcRenderer.invoke('vault:bio-support'),
     bioEnabled: (): Promise<boolean> => ipcRenderer.invoke('vault:bio-enabled'),
-    bioEnable: (): Promise<VaultResult> => ipcRenderer.invoke('vault:bio-enable'),
+    bioEnable: (scope: 'session' | 'persistent' = 'session'): Promise<VaultResult> =>
+      ipcRenderer.invoke('vault:bio-enable', scope),
+    bioScope: (): Promise<'session' | 'persistent' | null> => ipcRenderer.invoke('vault:bio-scope'),
     bioDisable: (): Promise<VaultResult> => ipcRenderer.invoke('vault:bio-disable'),
     bioUnlock: (): Promise<VaultResult> => ipcRenderer.invoke('vault:bio-unlock')
   },

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -225,6 +225,7 @@ const api = {
     bioEnable: (scope: 'session' | 'persistent' = 'session'): Promise<VaultResult> =>
       ipcRenderer.invoke('vault:bio-enable', scope),
     bioScope: (): Promise<'session' | 'persistent' | null> => ipcRenderer.invoke('vault:bio-scope'),
+    setAutoLock: (minutes: number): Promise<void> => ipcRenderer.invoke('vault:set-auto-lock', minutes),
     onAutoLocked: (cb: () => void): (() => void) => {
       const h = (): void => cb()
       ipcRenderer.on('vault:auto-locked', h)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -218,7 +218,13 @@ const api = {
     save: (entries: VaultEntry[]): Promise<VaultResult> => ipcRenderer.invoke('vault:save', entries),
     changePassword: (current: string, next: string): Promise<VaultResult> =>
       ipcRenderer.invoke('vault:change-password', current, next),
-    destroy: (): Promise<VaultResult> => ipcRenderer.invoke('vault:destroy')
+    destroy: (): Promise<VaultResult> => ipcRenderer.invoke('vault:destroy'),
+    bioSupport: (): Promise<{ available: boolean; kind: string; reason?: string }> =>
+      ipcRenderer.invoke('vault:bio-support'),
+    bioEnabled: (): Promise<boolean> => ipcRenderer.invoke('vault:bio-enabled'),
+    bioEnable: (): Promise<VaultResult> => ipcRenderer.invoke('vault:bio-enable'),
+    bioDisable: (): Promise<VaultResult> => ipcRenderer.invoke('vault:bio-disable'),
+    bioUnlock: (): Promise<VaultResult> => ipcRenderer.invoke('vault:bio-unlock')
   },
   workspaceLock: {
     ids: (): Promise<string[]> => ipcRenderer.invoke('wslock:ids'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -18,6 +18,7 @@ import { AiPanel } from './components/ai/AiPanel'
 import { ApprovalWatcher } from './components/ai/ApprovalWatcher'
 import { AgentServerWatcher } from './components/ai/AgentServerWatcher'
 import { VaultUnlockModal } from './components/vault/VaultUnlockModal'
+import { OnboardingTour } from './components/onboarding/OnboardingTour'
 import { CliPairingBanner } from './components/ai/CliPairingBanner'
 import { CommandPalette } from './components/palette/CommandPalette'
 import { AddServerModal } from './components/connections/AddServerModal'
@@ -106,6 +107,7 @@ export default function App(): React.JSX.Element {
       <ApprovalWatcher />
       <AgentServerWatcher />
       <VaultUnlockModal />
+      <OnboardingTour />
       <CliPairingBanner />
       <Toasts />
     </div>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -17,6 +17,7 @@ import { VaultView } from './components/vault/VaultView'
 import { AiPanel } from './components/ai/AiPanel'
 import { ApprovalWatcher } from './components/ai/ApprovalWatcher'
 import { AgentServerWatcher } from './components/ai/AgentServerWatcher'
+import { VaultUnlockModal } from './components/vault/VaultUnlockModal'
 import { CliPairingBanner } from './components/ai/CliPairingBanner'
 import { CommandPalette } from './components/palette/CommandPalette'
 import { AddServerModal } from './components/connections/AddServerModal'
@@ -104,6 +105,7 @@ export default function App(): React.JSX.Element {
       {/* Surfaces an AI approval request no matter which tab is active. */}
       <ApprovalWatcher />
       <AgentServerWatcher />
+      <VaultUnlockModal />
       <CliPairingBanner />
       <Toasts />
     </div>

--- a/src/renderer/src/components/connections/AddServerModal.tsx
+++ b/src/renderer/src/components/connections/AddServerModal.tsx
@@ -5,6 +5,7 @@ import { useApp } from '../../store/app'
 import { RouteHops } from './RouteHops'
 import { toast } from '../../store/toast'
 import { clsx } from '../../lib/format'
+import { useVault } from '../../store/vault'
 import type { AuthMethod, Hop } from '../../types'
 
 const AUTH: { id: AuthMethod; label: string; icon: React.ReactNode }[] = [
@@ -29,6 +30,9 @@ export function AddServerModal(): React.JSX.Element {
   const [username, setUsername] = useState(existing?.username ?? 'root')
   const [auth, setAuth] = useState<AuthMethod>(existing?.auth ?? 'key')
   const [keyPath, setKeyPath] = useState('')
+  // '' means "enter a new one"; anything else is a vault entry id.
+  const [vaultEntryId, setVaultEntryId] = useState('')
+  const [saveToVault, setSaveToVault] = useState(true)
   const [foundKeys, setFoundKeys] = useState<
     { path: string; fileName: string; algorithm: string | null; encrypted: boolean }[]
   >([])
@@ -41,6 +45,17 @@ export function AddServerModal(): React.JSX.Element {
   const [hostKeyCheck, setHostKeyCheck] = useState(true)
   const [timeout, setTimeoutV] = useState('15')
   const [env, setEnv] = useState('')
+
+  const vaultUnlocked = useVault((s) => s.unlocked)
+  const vaultEntries = useVault((s) => s.entries)
+  const createVaultEntry = useVault((s) => s.createEntry)
+
+  // A credential is only offered for the method it can actually satisfy: a
+  // password entry cannot authenticate a key connection, and vice versa.
+  const usableEntries = vaultEntries.filter((e) =>
+    auth === 'key' ? !!e.privateKey : auth === 'password' ? !!e.password && !e.privateKey : false
+  )
+  const usingVault = vaultUnlocked && vaultEntryId !== ''
 
   const valid = name.trim() && host.trim()
 
@@ -69,15 +84,33 @@ export function AddServerModal(): React.JSX.Element {
     }
     const id = editId ? (updateServer(editId, fields), editId) : addServer(fields)
 
-    // Credentials live in OS secure storage, keyed by server id. On an edit,
-    // blank fields mean "leave what is already stored alone".
-    const secret =
-      auth === 'password'
-        ? { password }
-        : auth === 'key'
-          ? { keyPath: keyPath.trim() || undefined, passphrase: passphrase || undefined }
-          : null
-    if (secret && (secret.password || secret.keyPath)) {
+    // What gets stored against the server is a reference wherever possible.
+    // A credential in the vault is one record — reusable across every server
+    // that uses it, and changed in one place when it rotates — whereas a copy
+    // per server is what makes rotation a hunt.
+    let secret: Record<string, string | undefined> | null = null
+
+    if (usingVault) {
+      secret = { vaultEntryId }
+    } else if (auth === 'password' && password) {
+      secret = saveToVault && vaultUnlocked ? null : { password }
+      if (!secret) {
+        const entryId = await createVaultEntry('login', {
+          name: `${fields.name} (${fields.username})`,
+          username: fields.username,
+          password,
+          tags: ['server']
+        })
+        // Falling back to the keychain beats losing the credential the user
+        // just typed because the vault write failed.
+        secret = entryId ? { vaultEntryId: entryId } : { password }
+        if (!entryId) toast('Could not save to the vault — kept in OS secure storage', 'error')
+      }
+    } else if (auth === 'key' && keyPath.trim()) {
+      secret = { keyPath: keyPath.trim(), passphrase: passphrase || undefined }
+    }
+
+    if (secret) {
       const ok = await window.shellpilot?.secrets.set(id, JSON.stringify(secret))
       if (ok === false) toast('OS secure storage unavailable — credentials not saved', 'error')
     }
@@ -148,7 +181,36 @@ export function AddServerModal(): React.JSX.Element {
         </div>
       </div>
 
-      {auth === 'key' && (
+      {auth !== 'agent' && vaultUnlocked && usableEntries.length > 0 && (
+        <div className="field">
+          <label className="field-label">Credential</label>
+          <select className="input" value={vaultEntryId} onChange={(e) => setVaultEntryId(e.target.value)}>
+            <option value="">Enter a new one…</option>
+            {usableEntries.map((e) => (
+              <option key={e.id} value={e.id}>
+                {e.name}
+                {e.username ? ` — ${e.username}` : ''}
+              </option>
+            ))}
+          </select>
+          <span className="field-hint">
+            {usingVault
+              ? 'This server will reference the vault entry. Change the credential there and every server using it follows.'
+              : 'Reuse a credential you have already saved, or type a new one below.'}
+          </span>
+        </div>
+      )}
+
+      {auth !== 'agent' && vaultUnlocked && usableEntries.length === 0 && (
+        <div className="field">
+          <span className="field-hint">
+            No saved {auth === 'key' ? 'SSH key' : 'login'} in the vault yet — type one below and it
+            will be saved there.
+          </span>
+        </div>
+      )}
+
+      {auth === 'key' && !usingVault && (
         <div className="field">
           <label className="field-label">Private key</label>
           <div className="input-group">
@@ -193,7 +255,7 @@ export function AddServerModal(): React.JSX.Element {
         </div>
       )}
 
-      {auth === 'password' && (
+      {auth === 'password' && !usingVault && (
         <div className="field">
           <label className="field-label">Password</label>
           <input
@@ -203,7 +265,17 @@ export function AddServerModal(): React.JSX.Element {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
           />
-          <span className="field-hint">Encrypted with the OS keychain.</span>
+          {vaultUnlocked ? (
+            <label className="field-hint row" style={{ gap: 6, cursor: 'pointer', marginTop: 6 }}>
+              <input type="checkbox" checked={saveToVault} onChange={(e) => setSaveToVault(e.target.checked)} />
+              Save this to the vault as a reusable credential
+            </label>
+          ) : (
+            <span className="field-hint">
+              Encrypted with the OS keychain. Unlock the vault first to save it as a reusable
+              credential instead.
+            </span>
+          )}
         </div>
       )}
 

--- a/src/renderer/src/components/monitor/FleetMonitor.tsx
+++ b/src/renderer/src/components/monitor/FleetMonitor.tsx
@@ -15,6 +15,7 @@ import { ServerMonitorCard } from './ServerMonitorCard'
 import { fleetTotals, useFleet } from '../../store/fleet'
 import { bytes, clsx } from '../../lib/format'
 import type { MonitorGroup, Server } from '../../types'
+import { FleetServices } from './FleetServices'
 
 function pct(used: number, total: number): number {
   return total > 0 ? (used / total) * 100 : 0
@@ -305,6 +306,8 @@ export function FleetMonitor(): React.JSX.Element {
           </div>
         </div>
       )}
+
+      <FleetServices servers={servers} />
 
       <div
         className="monitor-groups"

--- a/src/renderer/src/components/monitor/FleetServices.tsx
+++ b/src/renderer/src/components/monitor/FleetServices.tsx
@@ -1,0 +1,129 @@
+import { useMemo, useState } from 'react'
+import { ChevronDown, ChevronRight, CircleAlert, Network } from 'lucide-react'
+import { useFleet } from '../../store/fleet'
+import { clsx } from '../../lib/format'
+import type { Server } from '../../types'
+
+// Services and listening ports across the estate.
+//
+// Reads what the metrics poll already collected, so this opens no connections
+// of its own — same arrangement as the capacity totals above it.
+export function FleetServices({ servers }: { servers: Server[] }): React.JSX.Element | null {
+  const hosts = useFleet((s) => s.hosts)
+  const [open, setOpen] = useState<string | null>(null)
+
+  const rows = useMemo(
+    () =>
+      servers
+        .map((s) => ({ server: s, host: hosts[s.id] }))
+        .filter((r) => r.host && (r.host.services !== null || r.host.listeners !== null))
+        .map((r) => ({
+          ...r,
+          failed: (r.host.services ?? []).filter((u) => u.active === 'failed' || u.sub === 'failed'),
+          running: (r.host.services ?? []).filter((u) => u.sub === 'running'),
+          listeners: r.host.listeners ?? []
+        })),
+    [servers, hosts]
+  )
+
+  const totalFailed = rows.reduce((n, r) => n + r.failed.length, 0)
+
+  // Nothing has reported a probe result yet, so there is nothing truthful to
+  // say — better than a panel of zeroes that looks like an answer.
+  if (rows.length === 0) return null
+
+  return (
+    <div className="fleet-services">
+      <div className="row" style={{ gap: 8, alignItems: 'center', marginBottom: 8 }}>
+        <b>Services and ports</b>
+        <span className="server-meta">
+          {rows.length} {rows.length === 1 ? 'host' : 'hosts'} reporting
+        </span>
+        {totalFailed > 0 && (
+          <span className="badge danger">
+            <CircleAlert size={12} /> {totalFailed} failed
+          </span>
+        )}
+      </div>
+
+      {rows.map(({ server, host, failed, running, listeners }) => {
+        const isOpen = open === server.id
+        return (
+          <div className="list-row" key={server.id} style={{ flexWrap: 'wrap' }}>
+            <button className="btn sm ghost" onClick={() => setOpen(isOpen ? null : server.id)}>
+              {isOpen ? <ChevronDown size={13} /> : <ChevronRight size={13} />} {server.name}
+            </button>
+            <span className="spacer" />
+
+            {host.services === null ? (
+              // A host without systemd is not a host with no services, and
+              // saying "0 services" would be a lie.
+              <span className="server-meta">no systemd</span>
+            ) : (
+              <span className={clsx('server-meta', failed.length > 0 && 'danger')}>
+                {failed.length > 0 ? `${failed.length} failed · ` : ''}
+                {running.length} running
+              </span>
+            )}
+
+            <span className="server-meta">
+              <Network size={12} />{' '}
+              {host.listeners === null
+                ? 'no ss or netstat'
+                : `${listeners.length} listening${host.listenerSource ? ` (${host.listenerSource})` : ''}`}
+            </span>
+
+            {isOpen && (
+              <div style={{ width: '100%', marginTop: 8 }}>
+                {failed.length > 0 && (
+                  <div style={{ marginBottom: 8 }}>
+                    <div className="s-desc">
+                      <b>Failed units</b>
+                    </div>
+                    {failed.map((u) => (
+                      <div key={u.name} className="s-desc danger">
+                        {u.name} — {u.description || u.sub}
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {listeners.length > 0 && (
+                  <table className="mini-table" style={{ width: '100%' }}>
+                    <thead>
+                      <tr>
+                        <th>Port</th>
+                        <th>Proto</th>
+                        <th>Address</th>
+                        <th>Process</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {listeners.map((l) => (
+                        <tr key={`${l.proto}-${l.address}-${l.port}`}>
+                          <td className="mono strong">{l.port}</td>
+                          <td className="mono">{l.proto}</td>
+                          <td className="mono">{l.address}</td>
+                          <td className="mono">
+                            {l.process ?? <span className="faint">not visible</span>}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+
+                {listeners.length > 0 && !listeners.some((l) => l.process) && (
+                  <div className="s-desc" style={{ marginTop: 6 }}>
+                    Process names need root on most systems, so they are blank when the monitoring
+                    account is unprivileged. The ports themselves are still accurate.
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/src/components/onboarding/OnboardingTour.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingTour.tsx
@@ -1,0 +1,107 @@
+import { useEffect } from 'react'
+import { ArrowLeft, ArrowRight, Check, Compass } from 'lucide-react'
+import { useOnboarding } from '../../store/onboarding'
+import { useApp } from '../../store/app'
+import { clsx } from '../../lib/format'
+import { TOUR_STEPS } from './tourSteps'
+
+// A first-run walkthrough, mounted once at the app root.
+//
+// Deliberately not a modal over a dimmed screen: each step switches to the
+// view it describes and the card sits in a corner, so the feature is visible
+// while it is explained. A tour that hides the app while describing it teaches
+// nothing you can act on.
+export function OnboardingTour(): React.JSX.Element | null {
+  const open = useOnboarding((s) => s.open)
+  const step = useOnboarding((s) => s.step)
+  const next = useOnboarding((s) => s.next)
+  const back = useOnboarding((s) => s.back)
+  const goTo = useOnboarding((s) => s.goTo)
+  const finish = useOnboarding((s) => s.finish)
+  const openIfFirstRun = useOnboarding((s) => s.openIfFirstRun)
+  const setActivity = useApp((s) => s.setActivity)
+
+  useEffect(() => {
+    openIfFirstRun()
+  }, [openIfFirstRun])
+
+  const current = TOUR_STEPS[step]
+
+  // Move the app to whatever this step is about.
+  useEffect(() => {
+    if (open && current?.view) setActivity(current.view)
+  }, [open, current?.view, setActivity])
+
+  // Escape closes it, the same as Skip — a tour you cannot dismiss with the
+  // obvious key is a trap.
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') finish()
+      if (e.key === 'ArrowRight') step < TOUR_STEPS.length - 1 ? next() : finish()
+      if (e.key === 'ArrowLeft') back()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, step, next, back, finish])
+
+  if (!open || !current) return null
+  const last = step === TOUR_STEPS.length - 1
+
+  return (
+    <div className="tour-card" role="dialog" aria-label="ShellPilot walkthrough">
+      <div className="row" style={{ gap: 8, alignItems: 'center' }}>
+        <Compass size={16} style={{ color: 'var(--accent)' }} />
+        <b>{current.title}</b>
+        <span className="spacer" />
+        <span className="server-meta">
+          {step + 1} / {TOUR_STEPS.length}
+        </span>
+      </div>
+
+      <div className="s-desc" style={{ marginTop: 8 }}>
+        {current.body}
+      </div>
+
+      {current.action && (
+        <div className="tour-action">
+          <Check size={12} /> {current.action}
+        </div>
+      )}
+
+      <div className="tour-dots">
+        {TOUR_STEPS.map((s, i) => (
+          <button
+            key={s.id}
+            className={clsx('tour-dot', i === step && 'active')}
+            aria-label={s.title}
+            onClick={() => goTo(i)}
+          />
+        ))}
+      </div>
+
+      <div className="row" style={{ gap: 8, marginTop: 10 }}>
+        <button className="btn sm" disabled={step === 0} onClick={back}>
+          <ArrowLeft size={13} /> Back
+        </button>
+        <button className="btn sm primary" onClick={() => (last ? finish() : next())}>
+          {last ? (
+            <>
+              <Check size={13} /> Done
+            </>
+          ) : (
+            <>
+              Next <ArrowRight size={13} />
+            </>
+          )}
+        </button>
+        <span className="spacer" />
+        {!last && (
+          <button className="btn sm ghost" onClick={finish}>
+            Skip
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/onboarding/tourSteps.ts
+++ b/src/renderer/src/components/onboarding/tourSteps.ts
@@ -1,0 +1,68 @@
+import type { ActivityView } from '../../types'
+
+export interface TourStep {
+  id: string
+  title: string
+  body: string
+  // Which view to switch to while this step shows, so the feature is on screen
+  // behind the card rather than merely described.
+  view?: ActivityView
+  // A concrete thing to try, where there is one worth naming.
+  action?: string
+}
+
+// Deliberately short. A tour people skip teaches nothing, so each step has to
+// earn its place by covering something you would otherwise find by accident:
+// that workspaces exist at all, that credentials belong in the vault rather
+// than on each server, that an AI agent never sees them.
+export const TOUR_STEPS: TourStep[] = [
+  {
+    id: 'welcome',
+    title: 'Welcome to ShellPilot',
+    body: 'An SSH terminal, SFTP browser, server monitor, tunnel manager, database client and encrypted vault in one window. This takes about a minute, and Settings can reopen it any time.'
+  },
+  {
+    id: 'workspaces',
+    title: 'Workspaces keep clients and environments apart',
+    body: 'Every server, database, tunnel and vault entry belongs to a workspace. Switch with the picker in the title bar. A workspace can be password-protected, so one client’s infrastructure stays invisible until you unlock it.',
+    action: 'Try the workspace picker at the top left.'
+  },
+  {
+    id: 'connections',
+    title: 'Connections, and jump hosts that chain',
+    body: 'Add a server once and reuse it everywhere. Each can route through unlimited jump hosts, each with its own credentials. Existing hosts import straight from your ~/.ssh/config.',
+    view: 'connections',
+    action: 'Add a server, or import your SSH config.'
+  },
+  {
+    id: 'vault',
+    title: 'The vault is where credentials live',
+    body: 'Passwords, SSH keys and API keys, encrypted with AES-256-GCM under a master password. A server references a vault entry rather than keeping its own copy, so rotating a credential is one edit instead of a hunt. On a Mac with Touch ID you can unlock with a fingerprint.',
+    view: 'vault',
+    action: 'Create your vault and add a credential.'
+  },
+  {
+    id: 'monitor',
+    title: 'Monitoring, including what is broken',
+    body: 'Live CPU, memory, disk and network per server, totalled across the fleet. Failed systemd units and listening ports come back on the same poll, so you can see what a host exposes and what has fallen over without opening a shell.',
+    view: 'monitor'
+  },
+  {
+    id: 'tunnels',
+    title: 'Tunnels, and databases behind a bastion',
+    body: 'Local and remote port forwards plus a SOCKS5 proxy. The database client speaks PostgreSQL, MySQL, SQL Server, MongoDB and Redis, and can reach a database that is only routable from inside the network.',
+    view: 'tunnels'
+  },
+  {
+    id: 'ai',
+    title: 'AI agents, without handing over credentials',
+    body: 'Claude Code, Claude Desktop and Codex can run commands and read files through ShellPilot, but never see a password, key, hostname or username. You choose per capability what is allowed, asked about or refused, and every action lands in the audit log.',
+    view: 'ai',
+    action: 'AI & MCP → Overview → Connect, when you want it.'
+  },
+  {
+    id: 'done',
+    title: 'That is the tour',
+    body: 'Cmd/Ctrl+K opens the command palette, which reaches everything here. Shortcuts are rebindable in Settings, and this walkthrough is there too if you want it again.'
+  }
+]

--- a/src/renderer/src/components/onboarding/tourSteps.ts
+++ b/src/renderer/src/components/onboarding/tourSteps.ts
@@ -24,7 +24,7 @@ export const TOUR_STEPS: TourStep[] = [
   {
     id: 'workspaces',
     title: 'Workspaces keep clients and environments apart',
-    body: 'Every server, database, tunnel and vault entry belongs to a workspace. Switch with the picker in the title bar. A workspace can be password-protected, so one client’s infrastructure stays invisible until you unlock it.',
+    body: 'Servers, databases and tunnels each belong to a workspace — switch with the picker in the title bar, and password-protect a workspace to keep one client’s infrastructure out of sight. The vault is the exception: it is shared across every workspace, so a credential you save is visible from all of them.',
     action: 'Try the workspace picker at the top left.'
   },
   {
@@ -37,7 +37,7 @@ export const TOUR_STEPS: TourStep[] = [
   {
     id: 'vault',
     title: 'The vault is where credentials live',
-    body: 'Passwords, SSH keys and API keys, encrypted with AES-256-GCM under a master password. A server references a vault entry rather than keeping its own copy, so rotating a credential is one edit instead of a hunt. On a Mac with Touch ID you can unlock with a fingerprint.',
+    body: 'Passwords, SSH keys and API keys, encrypted with AES-256-GCM under a master password. One vault for the whole app, not one per workspace — a server in any workspace can reference the same entry, so rotating a credential is one edit instead of a hunt. On a Mac with Touch ID you can unlock with a fingerprint.',
     view: 'vault',
     action: 'Create your vault and add a credential.'
   },

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -12,14 +12,14 @@ import {
   Keyboard,
   Bell,
   Wrench,
-  DatabaseBackup
-} from 'lucide-react'
+  DatabaseBackup, Compass } from 'lucide-react'
 import { useApp } from '../../store/app'
 import type { ThemeMode } from '../../store/app'
 import { clsx } from '../../lib/format'
 import { ShortcutManager } from './ShortcutManager'
 import { BackupPanel } from './BackupPanel'
 import { UpdatePanel } from './UpdatePanel'
+import { useOnboarding } from '../../store/onboarding'
 import { SshSessions } from './SshSessions'
 import { toast } from '../../store/toast'
 
@@ -129,6 +129,7 @@ function Toggle({ label, desc, initial = false }: { label: string; desc: string;
 
 export function Settings(): React.JSX.Element {
   const [section, setSection] = useState<SectionId>('appearance')
+  const startTour = useOnboarding((s) => s.start)
   const theme = useApp((s) => s.theme)
   const setTheme = useApp((s) => s.setTheme)
   const settings = useApp((s) => s.settings)
@@ -153,6 +154,25 @@ export function Settings(): React.JSX.Element {
 
         <div className="settings-content">
           {section === 'general' && <UpdatePanel />}
+
+          {section === 'general' && (
+            <div className="settings-section">
+              <h2>Walkthrough</h2>
+              <div className="sub">A short tour of what is here and where it lives.</div>
+              <div className="setting-row">
+                <div className="s-info">
+                  <div className="s-title">Show the walkthrough</div>
+                  <div className="s-desc">
+                    Runs once on a first launch. Reopen it here whenever you want — it switches to
+                    each feature as it describes it, so nothing is hidden while you read.
+                  </div>
+                </div>
+                <button className="btn sm" onClick={() => startTour()}>
+                  <Compass size={13} /> Start walkthrough
+                </button>
+              </div>
+            </div>
+          )}
 
           {section === 'appearance' && (
             <div className="settings-section">

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -354,6 +354,35 @@ export function Settings(): React.JSX.Element {
 
           {section === 'security' && (
             <div className="settings-section">
+              <h2>Vault</h2>
+              <div className="sub">The encrypted store for passwords, SSH keys and API keys.</div>
+              <div className="setting-row">
+                <div className="s-info">
+                  <div className="s-title">Lock after inactivity</div>
+                  <div className="s-desc">
+                    While the vault is unlocked its key is in memory and its entries are on screen.
+                    Locking clears both. The timer counts vault inactivity, not time since you
+                    started the app.
+                  </div>
+                </div>
+                <select
+                  className="input"
+                  style={{ maxWidth: 160 }}
+                  value={settings.vaultAutoLockMinutes}
+                  onChange={(e) => setSettings({ vaultAutoLockMinutes: Number(e.target.value) })}
+                >
+                  <option value={5}>5 minutes</option>
+                  <option value={15}>15 minutes</option>
+                  <option value={30}>30 minutes</option>
+                  <option value={60}>1 hour</option>
+                  <option value={0}>Never</option>
+                </select>
+              </div>
+            </div>
+          )}
+
+          {section === 'security' && (
+            <div className="settings-section">
               <h2>Security</h2>
               <div className="sub">Credential storage and workspace locking.</div>
               <KnownHosts />

--- a/src/renderer/src/components/terminal/TerminalView.tsx
+++ b/src/renderer/src/components/terminal/TerminalView.tsx
@@ -11,6 +11,7 @@ import { runShortcut } from '../../hooks/useHotkeys'
 import { sshHopsFor } from '../../lib/ssh'
 import type { Server } from '../../types'
 import type { SshAuth, SshCloseInfo } from '../../../../shared/ssh'
+import { withVaultUnlock } from '../../lib/withVaultUnlock'
 
 function themeFromCss(): Record<string, string> {
   const css = getComputedStyle(document.documentElement)
@@ -319,16 +320,26 @@ function useRealSession(
     })
 
     setServerStatus(server.id, 'connecting')
-    void bridge?.ssh.connect({
-      sessionId,
-      serverId: server.id,
-      host: server.host,
-      port: server.port,
-      username: server.username,
-      auth: asAuth(server.auth),
-      cols: term.cols,
-      rows: term.rows,
-      hops
+    // A credential kept in the vault is unreadable while the vault is locked.
+    // Rather than failing with instructions to go and unlock it and start
+    // again, ask here and carry straight on.
+    void withVaultUnlock(`Connecting to ${server.name}`, () =>
+      Promise.resolve(
+        bridge?.ssh.connect({
+          sessionId,
+          serverId: server.id,
+          host: server.host,
+          port: server.port,
+          username: server.username,
+          auth: asAuth(server.auth),
+          cols: term.cols,
+          rows: term.rows,
+          hops
+        })
+      )
+    ).catch((err) => {
+      setServerStatus(server.id, 'offline')
+      setDead(`Session closed · ${err instanceof Error ? err.message : String(err)}`)
     })
 
     const onInput = term.onData((d) => bridge?.ssh.write(sessionId, d))

--- a/src/renderer/src/components/vault/VaultSidebar.tsx
+++ b/src/renderer/src/components/vault/VaultSidebar.tsx
@@ -1,4 +1,4 @@
-import { KeyRound, Lock, Globe, StickyNote, User } from 'lucide-react'
+import { KeyRound, Lock, Globe, StickyNote, User, FileKey } from 'lucide-react'
 import { useVault } from '../../store/vault'
 import { clsx } from '../../lib/format'
 import { vaultMatches, type VaultKind } from '../../../../shared/vault'
@@ -7,6 +7,7 @@ const KIND_ICON: Record<VaultKind, React.ReactNode> = {
   login: <User size={13} className="faint" />,
   url: <Globe size={13} className="faint" />,
   key: <KeyRound size={13} className="faint" />,
+  sshkey: <FileKey size={13} className="faint" />,
   note: <StickyNote size={13} className="faint" />
 }
 

--- a/src/renderer/src/components/vault/VaultUnlockModal.tsx
+++ b/src/renderer/src/components/vault/VaultUnlockModal.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react'
+import { Eye, EyeOff, Fingerprint, Lock } from 'lucide-react'
+import { Modal } from '../common/Modal'
+import { useVault } from '../../store/vault'
+import { useVaultPrompt } from '../../store/vaultPrompt'
+
+const BIO_LABEL: Record<string, string> = {
+  'touch-id': 'Touch ID',
+  'windows-hello': 'Windows Hello'
+}
+
+// Mounted once at the app root. Something needed a vault credential and the
+// vault was locked — so ask, here, and let the caller carry on, instead of
+// failing with instructions the user has to go and follow somewhere else
+// before starting over.
+export function VaultUnlockModal(): React.JSX.Element | null {
+  const open = useVaultPrompt((s) => s.open)
+  const reason = useVaultPrompt((s) => s.reason)
+  const finish = useVaultPrompt((s) => s.finish)
+
+  const unlock = useVault((s) => s.unlock)
+  const busy = useVault((s) => s.busy)
+  const error = useVault((s) => s.error)
+  const clearError = useVault((s) => s.clearError)
+  const exists = useVault((s) => s.exists)
+  const bioAvailable = useVault((s) => s.bioAvailable)
+  const bioEnabled = useVault((s) => s.bioEnabled)
+  const bioKind = useVault((s) => s.bioKind)
+  const refreshBiometrics = useVault((s) => s.refreshBiometrics)
+  const unlockWithBiometrics = useVault((s) => s.unlockWithBiometrics)
+
+  const [password, setPassword] = useState('')
+  const [show, setShow] = useState(false)
+  const canUseBio = bioAvailable && bioEnabled
+
+  useEffect(() => {
+    if (open) void refreshBiometrics()
+  }, [open, refreshBiometrics])
+
+  // Same as the main gate: go straight to the prompt rather than to a button
+  // that opens a prompt.
+  useEffect(() => {
+    if (!open || !canUseBio) return
+    void unlockWithBiometrics().then((ok) => ok && finish(true))
+  }, [open, canUseBio, unlockWithBiometrics, finish])
+
+  if (!open) return null
+
+  const submit = async (): Promise<void> => {
+    if (!password || busy) return
+    if (await unlock(password)) {
+      setPassword('')
+      finish(true)
+    }
+  }
+
+  return (
+    <Modal
+      title="Vault locked"
+      subtitle={reason}
+      onClose={() => {
+        setPassword('')
+        finish(false)
+      }}
+    >
+      <div className="row" style={{ gap: 10, alignItems: 'flex-start', marginBottom: 12 }}>
+        <Lock size={18} style={{ color: 'var(--accent)', marginTop: 2 }} />
+        <div className="s-desc">
+          {exists
+            ? 'This credential is stored in your vault. Unlock it to continue — it stays unlocked for the rest of this session.'
+            : 'There is no vault on this machine yet, so this credential cannot be read.'}
+        </div>
+      </div>
+
+      {canUseBio && (
+        <button
+          className="btn primary"
+          style={{ width: '100%', marginBottom: 10 }}
+          disabled={busy}
+          onClick={() => void unlockWithBiometrics().then((ok) => ok && finish(true))}
+        >
+          <Fingerprint size={15} /> Unlock with {BIO_LABEL[bioKind] ?? 'biometrics'}
+        </button>
+      )}
+
+      <div className="row" style={{ gap: 6 }}>
+        <input
+          className="input"
+          style={{ flex: 1 }}
+          type={show ? 'text' : 'password'}
+          autoFocus
+          placeholder="Master password"
+          value={password}
+          onChange={(e) => {
+            clearError()
+            setPassword(e.target.value)
+          }}
+          onKeyDown={(e) => e.key === 'Enter' && void submit()}
+        />
+        <button className="icon-btn" title={show ? 'Hide' : 'Show'} onClick={() => setShow((v) => !v)}>
+          {show ? <EyeOff size={16} /> : <Eye size={16} />}
+        </button>
+      </div>
+
+      {error && <div className="vault-error" style={{ marginTop: 8 }}>{error}</div>}
+
+      <div className="row" style={{ gap: 8, marginTop: 14 }}>
+        <button className="btn sm primary" disabled={!password || busy} onClick={() => void submit()}>
+          Unlock and continue
+        </button>
+        <button
+          className="btn sm"
+          onClick={() => {
+            setPassword('')
+            finish(false)
+          }}
+        >
+          Cancel
+        </button>
+      </div>
+    </Modal>
+  )
+}

--- a/src/renderer/src/components/vault/VaultUnlockModal.tsx
+++ b/src/renderer/src/components/vault/VaultUnlockModal.tsx
@@ -37,12 +37,9 @@ export function VaultUnlockModal(): React.JSX.Element | null {
     if (open) void refreshBiometrics()
   }, [open, refreshBiometrics])
 
-  // Same as the main gate: go straight to the prompt rather than to a button
-  // that opens a prompt.
-  useEffect(() => {
-    if (!open || !canUseBio) return
-    void unlockWithBiometrics().then((ok) => ok && finish(true))
-  }, [open, canUseBio, unlockWithBiometrics, finish])
+  // Same as the main gate: the prompt is not fired automatically. See the note
+  // there — an unbidden biometric prompt teaches the reflex that makes prompts
+  // phishable, and this one is a gate rather than a cryptographic step.
 
   if (!open) return null
 

--- a/src/renderer/src/components/vault/VaultView.tsx
+++ b/src/renderer/src/components/vault/VaultView.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
-import { Copy, Eye, EyeOff, KeyRound, Lock, Plus, ShieldCheck, Trash2, Unlock } from 'lucide-react'
+import { Copy, Eye, EyeOff, Fingerprint, KeyRound, Lock, Plus, ShieldCheck, Trash2, Unlock } from 'lucide-react'
 import { useVault, newField } from '../../store/vault'
 import { toast } from '../../store/toast'
+import { clsx } from '../../lib/format'
 import {
   VAULT_KIND_LABEL,
   VAULT_KIND_FIELDS,
@@ -45,6 +46,13 @@ export function VaultView(): React.JSX.Element {
 
 // Create-master-password and unlock share a layout; only the copy and the
 // action differ.
+// What the platform actually calls it. Saying "Touch ID" on a Windows machine
+// would be worse than saying nothing.
+const BIO_LABEL: Record<string, string> = {
+  'touch-id': 'Touch ID',
+  'windows-hello': 'Windows Hello'
+}
+
 function VaultGate({ mode }: { mode: 'create' | 'unlock' }): React.JSX.Element {
   const create = useVault((s) => s.create)
   const unlock = useVault((s) => s.unlock)
@@ -55,6 +63,25 @@ function VaultGate({ mode }: { mode: 'create' | 'unlock' }): React.JSX.Element {
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
   const [show, setShow] = useState(false)
+
+  const bioAvailable = useVault((s) => s.bioAvailable)
+  const bioEnabled = useVault((s) => s.bioEnabled)
+  const bioKind = useVault((s) => s.bioKind)
+  const refreshBiometrics = useVault((s) => s.refreshBiometrics)
+  const unlockWithBiometrics = useVault((s) => s.unlockWithBiometrics)
+  const canUseBio = mode === 'unlock' && bioAvailable && bioEnabled
+
+  useEffect(() => {
+    void refreshBiometrics()
+  }, [refreshBiometrics])
+
+  // Offer the prompt straight away rather than making the user click a button
+  // to reach a prompt. Cancelling leaves the password field focused and ready,
+  // so this costs nothing if they would rather type.
+  useEffect(() => {
+    if (canUseBio) void unlockWithBiometrics()
+    // Only on the transition into being able to, never on every render.
+  }, [canUseBio, unlockWithBiometrics])
 
   const creating = mode === 'create'
   const mismatch = creating && confirm.length > 0 && password !== confirm
@@ -80,6 +107,17 @@ function VaultGate({ mode }: { mode: 'create' | 'unlock' }): React.JSX.Element {
             ? 'Pick a master password. It encrypts everything in the vault and is never stored — if you lose it, the contents cannot be recovered.'
             : 'Enter your master password to decrypt the vault for this session.'}
         </p>
+
+        {canUseBio && (
+          <button
+            className="btn primary"
+            style={{ width: '100%', marginBottom: 10 }}
+            disabled={busy}
+            onClick={() => void unlockWithBiometrics()}
+          >
+            <Fingerprint size={15} /> Unlock with {BIO_LABEL[bioKind] ?? 'biometrics'}
+          </button>
+        )}
 
         <div className="row" style={{ gap: 6, marginTop: 4 }}>
           <input
@@ -130,6 +168,16 @@ function VaultGate({ mode }: { mode: 'create' | 'unlock' }): React.JSX.Element {
 }
 
 function VaultBrowser(): React.JSX.Element {
+  const bioAvailable = useVault((s) => s.bioAvailable)
+  const bioEnabled = useVault((s) => s.bioEnabled)
+  const bioKind = useVault((s) => s.bioKind)
+  const setBiometrics = useVault((s) => s.setBiometrics)
+  const refreshBiometrics = useVault((s) => s.refreshBiometrics)
+
+  useEffect(() => {
+    void refreshBiometrics()
+  }, [refreshBiometrics])
+
   const entries = useVault((s) => s.entries)
   const selectedId = useVault((s) => s.selectedId)
   const lock = useVault((s) => s.lock)
@@ -146,6 +194,19 @@ function VaultBrowser(): React.JSX.Element {
         <b>Vault</b>
         <span className="server-meta">{entries.length} entries</span>
         <span className="spacer" />
+        {bioAvailable && (
+          <button
+            className={clsx('btn', 'sm', bioEnabled && 'active')}
+            title={
+              bioEnabled
+                ? `Stop unlocking with ${BIO_LABEL[bioKind] ?? 'biometrics'}, and delete the stored key`
+                : `Store this vault's key so ${BIO_LABEL[bioKind] ?? 'biometrics'} can unlock it`
+            }
+            onClick={() => void setBiometrics(!bioEnabled)}
+          >
+            <Fingerprint size={13} /> {BIO_LABEL[bioKind] ?? 'Biometrics'}: {bioEnabled ? 'on' : 'off'}
+          </button>
+        )}
         <button className="btn sm" onClick={() => setChanging((v) => !v)}>
           Change password
         </button>

--- a/src/renderer/src/components/vault/VaultView.tsx
+++ b/src/renderer/src/components/vault/VaultView.tsx
@@ -167,6 +167,54 @@ function VaultGate({ mode }: { mode: 'create' | 'unlock' }): React.JSX.Element {
   )
 }
 
+// Remembers a decline so the offer is made once, not every unlock. A UI
+// preference, so it lives with the UI rather than in the vault file.
+const BIO_OFFER_DISMISSED = 'shellpilot.vault.bioOfferDismissed'
+
+// Offered right after a successful unlock, which is the one moment the value
+// is obvious — the user has just typed a long password and is about to do it
+// again tomorrow. A toggle in the toolbar is discoverable only by someone
+// already looking for it, which is nobody.
+function BiometricOffer(): React.JSX.Element | null {
+  const bioAvailable = useVault((s) => s.bioAvailable)
+  const bioEnabled = useVault((s) => s.bioEnabled)
+  const bioKind = useVault((s) => s.bioKind)
+  const setBiometrics = useVault((s) => s.setBiometrics)
+  const [dismissed, setDismissed] = useState(() => localStorage.getItem(BIO_OFFER_DISMISSED) === '1')
+
+  if (!bioAvailable || bioEnabled || dismissed) return null
+  const label = BIO_LABEL[bioKind] ?? 'biometrics'
+
+  const decline = (): void => {
+    localStorage.setItem(BIO_OFFER_DISMISSED, '1')
+    setDismissed(true)
+  }
+
+  return (
+    <div className="vault-bio-offer">
+      <Fingerprint size={18} style={{ color: 'var(--accent)', flexShrink: 0 }} />
+      <div style={{ flex: 1 }}>
+        <div className="s-title">Unlock with {label} next time?</div>
+        <div className="s-desc">
+          {label} then opens this vault instead of your master password. Doing so stores the
+          vault&apos;s key on this Mac, encrypted by the system keychain — so it trades a little
+          security for not typing a long password every session. Your master password is never
+          stored, and you can turn this off at any time.
+        </div>
+      </div>
+      <button
+        className="btn sm primary"
+        onClick={() => void setBiometrics(true).then((ok) => ok && toast(`${label} unlock enabled`, 'ok'))}
+      >
+        Enable
+      </button>
+      <button className="btn sm" onClick={decline}>
+        Not now
+      </button>
+    </div>
+  )
+}
+
 function VaultBrowser(): React.JSX.Element {
   const bioAvailable = useVault((s) => s.bioAvailable)
   const bioEnabled = useVault((s) => s.bioEnabled)
@@ -217,6 +265,8 @@ function VaultBrowser(): React.JSX.Element {
           <Lock size={13} /> Lock
         </button>
       </div>
+
+      <BiometricOffer />
 
       {error && <div className="vault-error" style={{ margin: 12 }}>{error}</div>}
       {changing && <ChangePassword onDone={() => setChanging(false)} />}

--- a/src/renderer/src/components/vault/VaultView.tsx
+++ b/src/renderer/src/components/vault/VaultView.tsx
@@ -6,6 +6,24 @@ import { VAULT_KIND_LABEL, type VaultEntry, type VaultKind } from '../../../../s
 
 const KINDS: VaultKind[] = ['login', 'url', 'key', 'note']
 
+// Which of the built-in fields each kind actually shows. The picker used to
+// change nothing but an icon in the sidebar: every kind rendered URL, Username
+// and Password, so a Note asked for a password and an API key had nowhere
+// obvious to put the key. Name, tags, custom fields and notes are on every
+// kind and are not listed here.
+//
+// Switching kind never deletes anything. A value typed under one kind is still
+// stored, still searchable, and comes back if the kind is switched back — so
+// this only decides what is on screen, which is the one thing it should decide.
+const KIND_FIELDS: Record<VaultKind, { url: boolean; username: boolean; secret: 'password' | 'key' | null }> = {
+  login: { url: true, username: true, secret: 'password' },
+  url: { url: true, username: false, secret: null },
+  key: { url: true, username: false, secret: 'key' },
+  note: { url: false, username: false, secret: null }
+}
+
+const SECRET_LABEL: Record<'password' | 'key', string> = { password: 'Password', key: 'API key' }
+
 function copy(label: string, value: string): void {
   if (!value) return
   window.shellpilot?.clipboard.write(value)
@@ -208,6 +226,17 @@ function EntryEditor({ entry }: { entry: VaultEntry }): React.JSX.Element {
   const setField = (id: string, patch: Partial<(typeof entry.fields)[number]>): void =>
     set({ fields: entry.fields.map((f) => (f.id === id ? { ...f, ...patch } : f)) })
 
+  const shown = KIND_FIELDS[entry.kind] ?? KIND_FIELDS.login
+
+  // A value that belongs to a field this kind does not show is still stored and
+  // still searchable, but it is now invisible — so say so rather than let it
+  // look lost.
+  const hiddenWithValue = [
+    !shown.url && entry.url ? 'URL' : null,
+    !shown.username && entry.username ? 'username' : null,
+    !shown.secret && entry.password ? 'password' : null
+  ].filter(Boolean) as string[]
+
   return (
     <div className="vault-editor">
       <div className="row" style={{ gap: 8 }}>
@@ -236,22 +265,35 @@ function EntryEditor({ entry }: { entry: VaultEntry }): React.JSX.Element {
         </button>
       </div>
 
-      <Row label="URL" value={entry.url} onChange={(v) => set({ url: v })} placeholder="https://…" />
-      <Row label="Username" value={entry.username} onChange={(v) => set({ username: v })} />
-      <Row
-        label="Password"
-        value={entry.password}
-        onChange={(v) => set({ password: v })}
-        secret
-        revealed={!!revealed.__pw}
-        onReveal={() => toggle('__pw')}
-      />
+      {shown.url && (
+        <Row label="URL" value={entry.url} onChange={(v) => set({ url: v })} placeholder="https://…" />
+      )}
+      {shown.username && (
+        <Row label="Username" value={entry.username} onChange={(v) => set({ username: v })} />
+      )}
+      {shown.secret && (
+        <Row
+          label={SECRET_LABEL[shown.secret]}
+          value={entry.password}
+          onChange={(v) => set({ password: v })}
+          secret
+          revealed={!!revealed.__pw}
+          onReveal={() => toggle('__pw')}
+        />
+      )}
       <Row
         label="Tags"
         value={entry.tags.join(', ')}
         onChange={(v) => set({ tags: v.split(',').map((t) => t.trim()).filter(Boolean) })}
         placeholder="prod, aws"
       />
+
+      {hiddenWithValue.length > 0 && (
+        <div className="s-desc" style={{ marginTop: 8 }}>
+          This entry also has a stored {hiddenWithValue.join(' and ')}, kept but not shown for a{' '}
+          {VAULT_KIND_LABEL[entry.kind].toLowerCase()}. Switch the type back to see it.
+        </div>
+      )}
 
       <div className="vault-section-title">
         Custom fields

--- a/src/renderer/src/components/vault/VaultView.tsx
+++ b/src/renderer/src/components/vault/VaultView.tsx
@@ -3,6 +3,7 @@ import { Copy, Eye, EyeOff, Fingerprint, KeyRound, Lock, Plus, ShieldCheck, Tras
 import { useVault, newField } from '../../store/vault'
 import { toast } from '../../store/toast'
 import { clsx } from '../../lib/format'
+import { bridgeOn } from '../../lib/bridge'
 import {
   VAULT_KIND_LABEL,
   VAULT_KIND_FIELDS,
@@ -38,6 +39,18 @@ export function VaultView(): React.JSX.Element {
   useEffect(() => {
     void refresh()
   }, [refresh])
+
+  // Main locked the vault on an idle timeout. Drop the decrypted entries the
+  // renderer is holding — leaving them would make the lock cosmetic, since the
+  // plaintext lives here too.
+  useEffect(
+    () =>
+      bridgeOn('vault.onAutoLocked', window.shellpilot?.vault?.onAutoLocked, () => {
+        useVault.setState({ unlocked: false, entries: [], selectedId: null })
+        toast('Vault locked after inactivity')
+      }),
+    []
+  )
 
   if (!exists) return <VaultGate mode="create" />
   if (!unlocked) return <VaultGate mode="unlock" />
@@ -83,7 +96,13 @@ function VaultGate({ mode }: { mode: 'create' | 'unlock' }): React.JSX.Element {
 
   const creating = mode === 'create'
   const mismatch = creating && confirm.length > 0 && password !== confirm
-  const canSubmit = password.length >= (creating ? 8 : 1) && !mismatch && (!creating || confirm.length > 0)
+  // 12, not 8. The vault file is the thing an attacker copies, and against a
+  // stolen file the master password's length is worth more than anything the
+  // unlock UI does. Only applies to new vaults; an existing one is not forced
+  // to change on upgrade.
+  const MIN_PASSWORD = 12
+  const canSubmit =
+    password.length >= (creating ? MIN_PASSWORD : 1) && !mismatch && (!creating || confirm.length > 0)
 
   const submit = async (): Promise<void> => {
     if (!canSubmit || busy) return
@@ -123,7 +142,7 @@ function VaultGate({ mode }: { mode: 'create' | 'unlock' }): React.JSX.Element {
             type={show ? 'text' : 'password'}
             autoFocus
             style={{ flex: 1 }}
-            placeholder={creating ? 'Master password (min 8 characters)' : 'Master password'}
+            placeholder={creating ? `Master password (min ${MIN_PASSWORD} characters)` : 'Master password'}
             value={password}
             onChange={(e) => {
               clearError()

--- a/src/renderer/src/components/vault/VaultView.tsx
+++ b/src/renderer/src/components/vault/VaultView.tsx
@@ -2,9 +2,16 @@ import { useEffect, useState } from 'react'
 import { Copy, Eye, EyeOff, KeyRound, Lock, Plus, ShieldCheck, Trash2, Unlock } from 'lucide-react'
 import { useVault, newField } from '../../store/vault'
 import { toast } from '../../store/toast'
-import { VAULT_KIND_LABEL, type VaultEntry, type VaultKind } from '../../../../shared/vault'
+import {
+  VAULT_KIND_LABEL,
+  VAULT_KIND_FIELDS,
+  VAULT_SECRET_LABEL,
+  hiddenFieldsFor,
+  type VaultEntry,
+  type VaultKind
+} from '../../../../shared/vault'
 
-const KINDS: VaultKind[] = ['login', 'url', 'key', 'note']
+const KINDS: VaultKind[] = ['login', 'url', 'key', 'sshkey', 'note']
 
 // Which of the built-in fields each kind actually shows. The picker used to
 // change nothing but an icon in the sidebar: every kind rendered URL, Username
@@ -15,14 +22,6 @@ const KINDS: VaultKind[] = ['login', 'url', 'key', 'note']
 // Switching kind never deletes anything. A value typed under one kind is still
 // stored, still searchable, and comes back if the kind is switched back — so
 // this only decides what is on screen, which is the one thing it should decide.
-const KIND_FIELDS: Record<VaultKind, { url: boolean; username: boolean; secret: 'password' | 'key' | null }> = {
-  login: { url: true, username: true, secret: 'password' },
-  url: { url: true, username: false, secret: null },
-  key: { url: true, username: false, secret: 'key' },
-  note: { url: false, username: false, secret: null }
-}
-
-const SECRET_LABEL: Record<'password' | 'key', string> = { password: 'Password', key: 'API key' }
 
 function copy(label: string, value: string): void {
   if (!value) return
@@ -226,16 +225,12 @@ function EntryEditor({ entry }: { entry: VaultEntry }): React.JSX.Element {
   const setField = (id: string, patch: Partial<(typeof entry.fields)[number]>): void =>
     set({ fields: entry.fields.map((f) => (f.id === id ? { ...f, ...patch } : f)) })
 
-  const shown = KIND_FIELDS[entry.kind] ?? KIND_FIELDS.login
+  const shown = VAULT_KIND_FIELDS[entry.kind] ?? VAULT_KIND_FIELDS.login
 
   // A value that belongs to a field this kind does not show is still stored and
   // still searchable, but it is now invisible — so say so rather than let it
   // look lost.
-  const hiddenWithValue = [
-    !shown.url && entry.url ? 'URL' : null,
-    !shown.username && entry.username ? 'username' : null,
-    !shown.secret && entry.password ? 'password' : null
-  ].filter(Boolean) as string[]
+  const hiddenWithValue = hiddenFieldsFor(entry)
 
   return (
     <div className="vault-editor">
@@ -271,9 +266,28 @@ function EntryEditor({ entry }: { entry: VaultEntry }): React.JSX.Element {
       {shown.username && (
         <Row label="Username" value={entry.username} onChange={(v) => set({ username: v })} />
       )}
+      {shown.keys && (
+        <>
+          <Multiline
+            label="Private key"
+            value={entry.privateKey ?? ''}
+            onChange={(v) => set({ privateKey: v })}
+            placeholder={'-----BEGIN OPENSSH PRIVATE KEY-----\n…'}
+            secret
+            revealed={!!revealed.__privkey}
+            onReveal={() => toggle('__privkey')}
+          />
+          <Multiline
+            label="Public key"
+            value={entry.publicKey ?? ''}
+            onChange={(v) => set({ publicKey: v })}
+            placeholder="ssh-ed25519 AAAA… user@host"
+          />
+        </>
+      )}
       {shown.secret && (
         <Row
-          label={SECRET_LABEL[shown.secret]}
+          label={VAULT_SECRET_LABEL[shown.secret]}
           value={entry.password}
           onChange={(v) => set({ password: v })}
           secret
@@ -355,6 +369,56 @@ function EntryEditor({ entry }: { entry: VaultEntry }): React.JSX.Element {
 
       <div className="faint" style={{ fontSize: 11 }}>
         Updated {new Date(entry.updatedAt).toLocaleString()}
+      </div>
+    </div>
+  )
+}
+
+// PEM material is many lines long and unusable in a single-line input, which
+// is why storing the key itself was never practical before.
+function Multiline({
+  label,
+  value,
+  onChange,
+  placeholder,
+  secret,
+  revealed,
+  onReveal
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+  placeholder?: string
+  secret?: boolean
+  revealed?: boolean
+  onReveal?: () => void
+}): React.JSX.Element {
+  const masked = secret && !revealed && value.length > 0
+  return (
+    <div className="row" style={{ gap: 6, alignItems: 'flex-start' }}>
+      <span className="vault-label" style={{ paddingTop: 8 }}>
+        {label}
+      </span>
+      <textarea
+        className="input mono"
+        style={{ flex: 1, minHeight: 96, resize: 'vertical', lineHeight: 1.4 }}
+        spellCheck={false}
+        placeholder={placeholder}
+        // A revealed key is shown verbatim; a hidden one shows its shape, so
+        // you can tell an entry holds a key without exposing it on screen.
+        value={masked ? `${value.split('\n').length} lines hidden` : value}
+        readOnly={masked}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <div className="col" style={{ gap: 4 }}>
+        {secret && (
+          <button className="icon-btn sm" title="Reveal" onClick={onReveal}>
+            {revealed ? <EyeOff size={14} /> : <Eye size={14} />}
+          </button>
+        )}
+        <button className="icon-btn sm" title={`Copy ${label.toLowerCase()}`} onClick={() => copy(label, value)}>
+          <Copy size={14} />
+        </button>
       </div>
     </div>
   )

--- a/src/renderer/src/components/vault/VaultView.tsx
+++ b/src/renderer/src/components/vault/VaultView.tsx
@@ -194,21 +194,18 @@ function BiometricOffer(): React.JSX.Element | null {
       <div style={{ flex: 1 }}>
         <div className="s-title">Unlock with {label} next time?</div>
         <div className="s-desc">
-          {label} will open this vault instead of your master password, including after a restart.
-          To do that, ShellPilot stores the vault&apos;s key on this Mac in the system keychain.
+          {label} reopens the vault while ShellPilot is running. <b>Nothing extra is written to
+          disk</b> — you enter your master password once each time you start the app, and after
+          that {label} unlocks it.
           <br />
-          <b>What changes:</b> {label} confirms it is you, but it does not hold the key — the
-          keychain does, and software running under your macOS account could read it without a
-          fingerprint. Right now your master password is the one thing that is not on this machine.
-          Your SSH credentials are already stored this way, so this brings the vault down to the
-          same level rather than opening a new kind of risk.
-          <br />
-          Your master password is never stored. Turning this off deletes the stored key.
+          Your master password is never stored, and you can turn this off at any time.
         </div>
       </div>
       <button
         className="btn sm primary"
-        onClick={() => void setBiometrics(true).then((ok) => ok && toast(`${label} unlock enabled`, 'ok'))}
+        onClick={() =>
+          void setBiometrics(true, 'session').then((ok) => ok && toast(`${label} unlock enabled`, 'ok'))
+        }
       >
         Enable
       </button>
@@ -223,6 +220,7 @@ function VaultBrowser(): React.JSX.Element {
   const bioAvailable = useVault((s) => s.bioAvailable)
   const bioEnabled = useVault((s) => s.bioEnabled)
   const bioKind = useVault((s) => s.bioKind)
+  const bioScope = useVault((s) => s.bioScope)
   const setBiometrics = useVault((s) => s.setBiometrics)
   const refreshBiometrics = useVault((s) => s.refreshBiometrics)
 
@@ -256,7 +254,8 @@ function VaultBrowser(): React.JSX.Element {
             }
             onClick={() => void setBiometrics(!bioEnabled)}
           >
-            <Fingerprint size={13} /> {BIO_LABEL[bioKind] ?? 'Biometrics'}: {bioEnabled ? 'on' : 'off'}
+            <Fingerprint size={13} /> {BIO_LABEL[bioKind] ?? 'Biometrics'}:{' '}
+            {bioEnabled ? (bioScope === 'persistent' ? 'on, saved' : 'on, this session') : 'off'}
           </button>
         )}
         <button className="btn sm" onClick={() => setChanging((v) => !v)}>

--- a/src/renderer/src/components/vault/VaultView.tsx
+++ b/src/renderer/src/components/vault/VaultView.tsx
@@ -75,13 +75,11 @@ function VaultGate({ mode }: { mode: 'create' | 'unlock' }): React.JSX.Element {
     void refreshBiometrics()
   }, [refreshBiometrics])
 
-  // Offer the prompt straight away rather than making the user click a button
-  // to reach a prompt. Cancelling leaves the password field focused and ready,
-  // so this costs nothing if they would rather type.
-  useEffect(() => {
-    if (canUseBio) void unlockWithBiometrics()
-    // Only on the transition into being able to, never on every render.
-  }, [canUseBio, unlockWithBiometrics])
+  // Deliberately NOT fired automatically. The prompt is a gate, not a
+  // cryptographic step, and a prompt that appears unbidden every time the app
+  // opens trains people to touch the sensor without reading it — which is
+  // exactly the habit that makes a prompt worth phishing. The button is one
+  // click and says what it does.
 
   const creating = mode === 'create'
   const mismatch = creating && confirm.length > 0 && password !== confirm
@@ -196,10 +194,16 @@ function BiometricOffer(): React.JSX.Element | null {
       <div style={{ flex: 1 }}>
         <div className="s-title">Unlock with {label} next time?</div>
         <div className="s-desc">
-          {label} then opens this vault instead of your master password. Doing so stores the
-          vault&apos;s key on this Mac, encrypted by the system keychain — so it trades a little
-          security for not typing a long password every session. Your master password is never
-          stored, and you can turn this off at any time.
+          {label} will open this vault instead of your master password, including after a restart.
+          To do that, ShellPilot stores the vault&apos;s key on this Mac in the system keychain.
+          <br />
+          <b>What changes:</b> {label} confirms it is you, but it does not hold the key — the
+          keychain does, and software running under your macOS account could read it without a
+          fingerprint. Right now your master password is the one thing that is not on this machine.
+          Your SSH credentials are already stored this way, so this brings the vault down to the
+          same level rather than opening a new kind of risk.
+          <br />
+          Your master password is never stored. Turning this off deletes the stored key.
         </div>
       </div>
       <button

--- a/src/renderer/src/lib/withVaultUnlock.ts
+++ b/src/renderer/src/lib/withVaultUnlock.ts
@@ -1,0 +1,29 @@
+import { useVaultPrompt } from '../store/vaultPrompt'
+
+// Matches the marker credentialResolver.ts puts in the message. Electron
+// rewrites a rejected IPC handler's error, so the class does not survive but
+// the token does.
+const VAULT_LOCKED = 'SHELLPILOT_VAULT_LOCKED'
+
+export function isVaultLocked(err: unknown): boolean {
+  return err instanceof Error ? err.message.includes(VAULT_LOCKED) : String(err).includes(VAULT_LOCKED)
+}
+
+/**
+ * Runs an operation that may need a vault credential. If it fails only because
+ * the vault is locked, asks the user to unlock and runs it once more.
+ *
+ * Retrying once, not looping: if it fails again after a successful unlock the
+ * cause is something else, and asking a second time would just be a dialog the
+ * user cannot get rid of.
+ */
+export async function withVaultUnlock<T>(reason: string, run: () => Promise<T>): Promise<T> {
+  try {
+    return await run()
+  } catch (err) {
+    if (!isVaultLocked(err)) throw err
+    const unlocked = await useVaultPrompt.getState().request(reason)
+    if (!unlocked) throw err
+    return await run()
+  }
+}

--- a/src/renderer/src/store/app.ts
+++ b/src/renderer/src/store/app.ts
@@ -44,6 +44,10 @@ export interface AppSettings {
   // Minutes an authenticated SSH connection is kept alive after its last
   // session closes. 0 = close at once, -1 = keep until the app exits.
   sshMasterIdleMinutes: number
+  // Minutes of vault inactivity before it locks itself. 0 = never. A vault that
+  // never locks makes every other protection on it optional, so the default is
+  // deliberately short rather than off.
+  vaultAutoLockMinutes: number
   // Terminal font size in pixels, adjusted with Ctrl +/- and Ctrl+wheel.
   terminalFontSize: number
   // Host metrics docked under the terminal.
@@ -69,6 +73,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   lastBackupAt: null,
   switchHiddenWorkspaces: false,
   sshMasterIdleMinutes: 15,
+  vaultAutoLockMinutes: 15,
   terminalFontSize: 13,
   showMonitorStrip: false,
   resourceAlertsEnabled: true,

--- a/src/renderer/src/store/onboarding.ts
+++ b/src/renderer/src/store/onboarding.ts
@@ -1,0 +1,50 @@
+import { create } from 'zustand'
+
+// Whether the walkthrough has been seen. A UI preference, so it lives with the
+// UI rather than in the workspace data file — it is about this installation,
+// not about the servers in it, and it should not travel in an encrypted backup.
+const SEEN_KEY = 'shellpilot.onboarding.seen'
+
+interface OnboardingState {
+  open: boolean
+  step: number
+  start: () => void
+  next: () => void
+  back: () => void
+  goTo: (i: number) => void
+  finish: () => void
+  // Opens on a first run and never again on its own; Settings can always
+  // reopen it.
+  openIfFirstRun: () => void
+}
+
+export const useOnboarding = create<OnboardingState>((set, get) => ({
+  open: false,
+  step: 0,
+
+  start: () => set({ open: true, step: 0 }),
+  next: () => set({ step: get().step + 1 }),
+  back: () => set({ step: Math.max(0, get().step - 1) }),
+  goTo: (i) => set({ step: Math.max(0, i) }),
+
+  finish: () => {
+    // Written on finish AND on skip: someone who dismissed it has decided, and
+    // showing it again on next launch would be nagging.
+    try {
+      localStorage.setItem(SEEN_KEY, '1')
+    } catch {
+      /* private mode or a wiped profile: worst case it offers once more */
+    }
+    set({ open: false, step: 0 })
+  },
+
+  openIfFirstRun: () => {
+    let seen = false
+    try {
+      seen = localStorage.getItem(SEEN_KEY) === '1'
+    } catch {
+      seen = false
+    }
+    if (!seen) set({ open: true, step: 0 })
+  }
+}))

--- a/src/renderer/src/store/persist.ts
+++ b/src/renderer/src/store/persist.ts
@@ -60,12 +60,18 @@ export async function initPersistence(): Promise<void> {
     if (!st.isWorkspaceAccessible(st.activeWorkspaceId)) st.lockWorkspace(st.activeWorkspaceId)
   }
 
+  // Main owns the vault's idle timer, same as the connection pool below.
+  void window.shellpilot?.vault?.setAutoLock?.(useApp.getState().settings.vaultAutoLockMinutes)
+
   // Main owns the connection pool, so mirror the retention policy into it.
   void window.shellpilot?.ssh.setPoolIdle(useApp.getState().settings.sshMasterIdleMinutes)
 
   useApp.subscribe((state, prev) => {
     if (state.settings.sshMasterIdleMinutes !== prev.settings.sshMasterIdleMinutes) {
       void window.shellpilot?.ssh.setPoolIdle(state.settings.sshMasterIdleMinutes)
+    }
+    if (state.settings.vaultAutoLockMinutes !== prev.settings.vaultAutoLockMinutes) {
+      void window.shellpilot?.vault?.setAutoLock?.(state.settings.vaultAutoLockMinutes)
     }
     const serversRefChanged = state.servers !== prev.servers
     const monitorGroupsRefChanged = state.monitorGroups !== prev.monitorGroups

--- a/src/renderer/src/store/vault.ts
+++ b/src/renderer/src/store/vault.ts
@@ -59,7 +59,8 @@ interface VaultState {
   bioEnabled: boolean
   refreshBiometrics: () => Promise<void>
   unlockWithBiometrics: () => Promise<boolean>
-  setBiometrics: (on: boolean) => Promise<boolean>
+  bioScope: 'session' | 'persistent' | null
+  setBiometrics: (on: boolean, scope?: 'session' | 'persistent') => Promise<boolean>
 }
 
 // Entries only ever live here while the vault is unlocked; locking drops them.
@@ -75,16 +76,22 @@ export const useVault = create<VaultState>((set, get) => ({
   bioKind: 'none',
   bioReason: null,
   bioEnabled: false,
+  bioScope: null,
 
   refreshBiometrics: async () => {
     const v = window.shellpilot?.vault
     if (typeof v?.bioSupport !== 'function') return
-    const [support, enabled] = await Promise.all([v.bioSupport(), v.bioEnabled()])
+    const [support, enabled, scope] = await Promise.all([
+      v.bioSupport(),
+      v.bioEnabled(),
+      typeof v.bioScope === 'function' ? v.bioScope() : Promise.resolve(null)
+    ])
     set({
       bioAvailable: !!support?.available,
       bioKind: support?.kind ?? 'none',
       bioReason: support?.reason ?? null,
-      bioEnabled: !!enabled
+      bioEnabled: !!enabled,
+      bioScope: scope ?? null
     })
   },
 
@@ -106,10 +113,10 @@ export const useVault = create<VaultState>((set, get) => ({
     return true
   },
 
-  setBiometrics: async (on) => {
+  setBiometrics: async (on, scope = 'session') => {
     const v = window.shellpilot?.vault
     if (typeof v?.bioEnable !== 'function') return false
-    const r = on ? await v.bioEnable() : await v.bioDisable()
+    const r = on ? await v.bioEnable(scope) : await v.bioDisable()
     await get().refreshBiometrics()
     if (!r?.ok) set({ error: r?.error ?? 'Could not change biometric unlock.' })
     return !!r?.ok

--- a/src/renderer/src/store/vault.ts
+++ b/src/renderer/src/store/vault.ts
@@ -51,6 +51,15 @@ interface VaultState {
   updateEntry: (id: string, patch: Partial<VaultEntry>) => Promise<void>
   deleteEntry: (id: string) => Promise<void>
   clearError: () => void
+  // Biometric unlock. `bioKind` is what to call it on this platform, so the
+  // UI never says "Touch ID" on a machine that does not have one.
+  bioAvailable: boolean
+  bioKind: string
+  bioReason: string | null
+  bioEnabled: boolean
+  refreshBiometrics: () => Promise<void>
+  unlockWithBiometrics: () => Promise<boolean>
+  setBiometrics: (on: boolean) => Promise<boolean>
 }
 
 // Entries only ever live here while the vault is unlocked; locking drops them.
@@ -62,6 +71,49 @@ export const useVault = create<VaultState>((set, get) => ({
   query: '',
   error: null,
   busy: false,
+  bioAvailable: false,
+  bioKind: 'none',
+  bioReason: null,
+  bioEnabled: false,
+
+  refreshBiometrics: async () => {
+    const v = window.shellpilot?.vault
+    if (typeof v?.bioSupport !== 'function') return
+    const [support, enabled] = await Promise.all([v.bioSupport(), v.bioEnabled()])
+    set({
+      bioAvailable: !!support?.available,
+      bioKind: support?.kind ?? 'none',
+      bioReason: support?.reason ?? null,
+      bioEnabled: !!enabled
+    })
+  },
+
+  unlockWithBiometrics: async () => {
+    const v = window.shellpilot?.vault
+    if (typeof v?.bioUnlock !== 'function') return false
+    set({ busy: true, error: null })
+    const r = await v.bioUnlock()
+    set({ busy: false })
+    if (!r?.ok) {
+      // A cancelled prompt should not shout; the password field is right
+      // there and is the expected fallback.
+      set({ error: r?.error ?? 'Biometric unlock failed.' })
+      await get().refreshBiometrics()
+      return false
+    }
+    set({ unlocked: true })
+    await get().refresh()
+    return true
+  },
+
+  setBiometrics: async (on) => {
+    const v = window.shellpilot?.vault
+    if (typeof v?.bioEnable !== 'function') return false
+    const r = on ? await v.bioEnable() : await v.bioDisable()
+    await get().refreshBiometrics()
+    if (!r?.ok) set({ error: r?.error ?? 'Could not change biometric unlock.' })
+    return !!r?.ok
+  },
 
   refresh: async () => {
     const st = await window.shellpilot?.vault.status()

--- a/src/renderer/src/store/vault.ts
+++ b/src/renderer/src/store/vault.ts
@@ -44,6 +44,10 @@ interface VaultState {
   select: (id: string | null) => void
   setQuery: (q: string) => void
   addEntry: (kind?: VaultKind) => Promise<void>
+  // Creates a fully-populated entry and hands back its id, so a caller that
+  // needs to reference the new entry — saving a server's credential into the
+  // vault — does not have to guess which one it just made.
+  createEntry: (kind: VaultKind, patch: Partial<VaultEntry>) => Promise<string | null>
   updateEntry: (id: string, patch: Partial<VaultEntry>) => Promise<void>
   deleteEntry: (id: string) => Promise<void>
   clearError: () => void
@@ -128,6 +132,16 @@ export const useVault = create<VaultState>((set, get) => ({
     const entries = [...get().entries, e]
     set({ entries, selectedId: e.id })
     await persist(entries, set)
+  },
+
+  createEntry: async (kind, patch) => {
+    const e = { ...newEntry(kind), ...patch }
+    const entries = [...get().entries, e]
+    set({ entries })
+    await persist(entries, set)
+    // persist() surfaces a failure through `error`; a caller must not be told
+    // an id that was never written to disk.
+    return get().error ? null : e.id
   },
 
   updateEntry: async (id, patch) => {

--- a/src/renderer/src/store/vaultPrompt.ts
+++ b/src/renderer/src/store/vaultPrompt.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand'
+
+// A single place anything can ask "the vault needs to be open for this" and be
+// answered by the user, rather than each caller inventing its own dialog — or,
+// as before, the operation simply failing with advice the user then has to act
+// on manually and retry by hand.
+
+interface VaultPromptState {
+  open: boolean
+  reason: string
+  resolve: ((unlocked: boolean) => void) | null
+  request: (reason: string) => Promise<boolean>
+  finish: (unlocked: boolean) => void
+}
+
+export const useVaultPrompt = create<VaultPromptState>((set, get) => ({
+  open: false,
+  reason: '',
+  resolve: null,
+
+  request: (reason) =>
+    new Promise<boolean>((resolve) => {
+      // A second request while one is already open joins the first rather than
+      // stacking dialogs: connecting to three servers at once should ask once.
+      const existing = get().resolve
+      set({
+        open: true,
+        reason,
+        resolve: (unlocked) => {
+          existing?.(unlocked)
+          resolve(unlocked)
+        }
+      })
+    }),
+
+  finish: (unlocked) => {
+    get().resolve?.(unlocked)
+    set({ open: false, resolve: null, reason: '' })
+  }
+}))

--- a/src/renderer/src/styles/global.css
+++ b/src/renderer/src/styles/global.css
@@ -2285,3 +2285,23 @@ button {
   color: var(--text);
   font-weight: 600;
 }
+
+/* Services and ports panel on the Fleet Monitor. Deliberately quiet: a failed
+   unit is the only thing here that should catch the eye. */
+.fleet-services {
+  margin: 18px 0 8px;
+}
+.fleet-services .badge.danger {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  color: var(--danger, #f87171);
+  border: 1px solid var(--danger, #f87171);
+}
+.fleet-services .server-meta.danger,
+.fleet-services .s-desc.danger {
+  color: var(--danger, #f87171);
+}

--- a/src/renderer/src/styles/global.css
+++ b/src/renderer/src/styles/global.css
@@ -2305,3 +2305,21 @@ button {
 .fleet-services .s-desc.danger {
   color: var(--danger, #f87171);
 }
+
+/* One-time offer to enable biometric unlock, shown after a password unlock.
+   Sits above the entry list rather than in a dialog: it is an offer, not a
+   question that has to be answered before the vault can be used. */
+.vault-bio-offer {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin: 12px 16px 0;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-elevated);
+}
+.vault-bio-offer .s-desc {
+  margin-top: 2px;
+  max-width: 62ch;
+}

--- a/src/renderer/src/styles/global.css
+++ b/src/renderer/src/styles/global.css
@@ -2323,3 +2323,52 @@ button {
   margin-top: 2px;
   max-width: 62ch;
 }
+
+/* First-run walkthrough. Anchored bottom-right rather than centred over a
+   scrim: each step switches to the view it is describing, and that view has to
+   stay visible for the step to mean anything. */
+.tour-card {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 900;
+  width: 380px;
+  max-width: calc(100vw - 40px);
+  padding: 14px 16px;
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  background: var(--bg-elevated);
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.45);
+}
+.tour-card .s-desc {
+  line-height: 1.5;
+}
+.tour-action {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+  padding: 7px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--accent);
+  background: var(--bg-card);
+}
+.tour-dots {
+  display: flex;
+  gap: 5px;
+  margin-top: 12px;
+}
+.tour-dot {
+  width: 6px;
+  height: 6px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  background: var(--border-strong);
+}
+.tour-dot.active {
+  background: var(--accent);
+  width: 16px;
+}

--- a/src/shared/ssh.ts
+++ b/src/shared/ssh.ts
@@ -84,6 +84,37 @@ export interface HostMetrics {
   hostname: string
   kernel: string
   cores: number
+  // null means the tool is not on the host at all — a container without
+  // systemd, or a box with neither ss nor netstat. That is a different thing
+  // from an empty list, which means the tool ran and found nothing, and the
+  // UI has to be able to tell them apart: "no failed services" and "cannot
+  // see services" are not the same answer.
+  services: ServiceUnit[] | null
+  listeners: PortListener[] | null
+  // Which probe produced the listeners, so the UI can say why the process
+  // column is empty on a host where only netstat exists and it ran unprivileged.
+  listenerSource: 'ss' | 'netstat' | null
+}
+
+// A systemd unit, as reported by `systemctl list-units`.
+export interface ServiceUnit {
+  name: string
+  // active | failed | activating | inactive
+  active: string
+  // running | exited | dead | failed
+  sub: string
+  description: string
+}
+
+// A socket in LISTEN state, from `ss` or `netstat`.
+export interface PortListener {
+  proto: string
+  address: string
+  port: number
+  // Only present when the probe ran with enough privilege to see the owner;
+  // an unprivileged user sees the socket but not whose it is.
+  process?: string
+  pid?: number
 }
 
 export interface MetricsResult {

--- a/src/shared/vault.ts
+++ b/src/shared/vault.ts
@@ -7,7 +7,7 @@ export interface VaultField {
   secret: boolean
 }
 
-export type VaultKind = 'login' | 'url' | 'key' | 'note'
+export type VaultKind = 'login' | 'url' | 'key' | 'sshkey' | 'note'
 
 export interface VaultEntry {
   id: string
@@ -15,7 +15,19 @@ export interface VaultEntry {
   kind: VaultKind
   url: string
   username: string
+  // Doubles as the key passphrase on an `sshkey` entry. One secret slot, whose
+  // label changes with the kind, rather than a second column that is null on
+  // every other kind.
   password: string
+  // PEM material for an `sshkey` entry. Optional because every other kind
+  // leaves them empty, and absent on entries written before this existed.
+  //
+  // The private key is stored here rather than referenced by path: a path is
+  // the one credential ShellPilot never actually held — not in the OS keychain,
+  // not in the encrypted vault, just a filename pointing at plaintext on disk,
+  // which also does not travel with an encrypted backup.
+  privateKey?: string
+  publicKey?: string
   notes: string
   tags: string[]
   fields: VaultField[]
@@ -44,6 +56,7 @@ export const VAULT_KIND_LABEL: Record<VaultKind, string> = {
   login: 'Login',
   url: 'URL',
   key: 'API key',
+  sshkey: 'SSH key',
   note: 'Note'
 }
 
@@ -57,8 +70,55 @@ export function vaultMatches(e: VaultEntry, query: string): boolean {
     e.url,
     e.username,
     e.notes,
+    // The public half is not a secret and is the useful thing to search by —
+    // it carries the key's comment, which is usually user@host. The private
+    // key and the passphrase are never in here, same as every other secret.
+    e.publicKey,
     ...e.tags,
     ...e.fields.flatMap((f) => [f.key, f.secret ? '' : f.value])
   ]
   return hay.some((h) => h?.toLowerCase().includes(q))
+}
+
+export type VaultSecretSlot = 'password' | 'key' | 'passphrase'
+
+export interface VaultKindFields {
+  url: boolean
+  username: boolean
+  secret: VaultSecretSlot | null
+  keys?: boolean
+}
+
+// Which built-in fields each kind shows. Lives here rather than in the view so
+// the tests exercise the real map: when this started as a copy inside the test
+// file, adding a kind left the copy behind and the coverage assertion was the
+// only thing that noticed.
+//
+// Name, tags, custom fields and notes are on every kind and are not listed.
+export const VAULT_KIND_FIELDS: Record<VaultKind, VaultKindFields> = {
+  login: { url: true, username: true, secret: 'password' },
+  url: { url: true, username: false, secret: null },
+  key: { url: true, username: false, secret: 'key' },
+  // username is the account the key logs in as, worth keeping beside the key
+  // rather than only on each server that uses it.
+  sshkey: { url: false, username: true, secret: 'passphrase', keys: true },
+  note: { url: false, username: false, secret: null }
+}
+
+export const VAULT_SECRET_LABEL: Record<VaultSecretSlot, string> = {
+  password: 'Password',
+  key: 'API key',
+  passphrase: 'Passphrase'
+}
+
+// Values an entry is holding that its current kind does not display. Stored and
+// searchable, but invisible — which is its own trap, so the UI says so.
+export function hiddenFieldsFor(e: VaultEntry): string[] {
+  const shown = VAULT_KIND_FIELDS[e.kind] ?? VAULT_KIND_FIELDS.login
+  return [
+    !shown.url && e.url ? 'URL' : null,
+    !shown.username && e.username ? 'username' : null,
+    !shown.secret && e.password ? 'password' : null,
+    !shown.keys && e.privateKey ? 'private key' : null
+  ].filter((v): v is string => v !== null)
 }

--- a/tests/addServer.integration.test.ts
+++ b/tests/addServer.integration.test.ts
@@ -4,7 +4,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 
 import { refreshMcpDataCache } from '../src/main/services/mcpDataCache'
 import { setAssignment, resetPolicyCacheForTests } from '../src/main/services/policyStore'
-import { setMcpConfig, createSession, setSessionGroup, listSessions, resetMcpAuthForTests } from '../src/main/services/mcpAuth'
+import { setMcpConfig, createSession, revokeSession, setSessionGroup, listSessions, resetMcpAuthForTests } from '../src/main/services/mcpAuth'
 import { startMcpServer, stopMcpServer, explainSessionAccess } from '../src/main/services/mcpServer'
 import { onApprovalEvent, respondToApproval } from '../src/main/services/approvals'
 import { listAudit } from '../src/main/services/auditLog'
@@ -319,6 +319,35 @@ describe('making the model legible', () => {
       expect(await call(c, { name: 'After Raise', host: '10.0.0.21' })).toContain('Added "After Raise"')
     } finally {
       stop()
+      await c.close()
+    }
+  })
+})
+
+describe('auth failures point at the half of the fix that works', () => {
+  it('tells a revoked client to re-register, not just to make a session', async () => {
+    // The reported loop: revoke, create a new session, restart the client,
+    // identical error — because the client still holds the dead token.
+    const { session, token } = createSession({
+      agentName: 'Revoked One',
+      workspaces: [{ id: 'ws-prod', name: 'Production' }],
+      groupId: 'grp-full',
+      groupName: 'Full Access',
+      ttlMinutes: null
+    })
+    revokeSession(session.id)
+
+    const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${PORT}/mcp`), {
+      requestInit: { headers: { Authorization: `Bearer ${token}` } }
+    })
+    const c = new Client({ name: 'revoked-test', version: '1.0.0' })
+    await c.connect(transport)
+    try {
+      const out = await call(c, { name: 'Nope', host: '10.0.0.30' })
+      expect(out).toContain('revoked')
+      expect(out).toContain('not enough on its own')
+      expect(out).toContain('Connect')
+    } finally {
       await c.close()
     }
   })

--- a/tests/biometrics.test.ts
+++ b/tests/biometrics.test.ts
@@ -181,3 +181,25 @@ describe('platforms without a biometric prompt', () => {
     if (!support.available) expect(support.kind).toBe('none')
   })
 })
+
+describe('failing closed', () => {
+  it('authenticates for a kind it knows', async () => {
+    if (!bio.biometricSupport().available) return
+    await expect(bio.authenticateFor('touch-id', 'test')).resolves.toBeUndefined()
+    expect(promptCalls).toHaveLength(1)
+  })
+
+  it('throws for a kind it has no prompt for, rather than falling through', async () => {
+    // Regression: written inline this was `if (kind === 'touch-id') await
+    // prompt()` — authenticate conditionally, then decrypt unconditionally.
+    // Adding a windows-hello branch to biometricSupport() without touching the
+    // unlock path would have shipped a vault that opens with no prompt at all.
+    await expect(bio.authenticateFor('windows-hello', 'test')).rejects.toThrow(/windows-hello/)
+    expect(promptCalls).toHaveLength(0)
+  })
+
+  it('throws for "none", which is what an unsupported platform reports', async () => {
+    await expect(bio.authenticateFor('none', 'test')).rejects.toThrow()
+    expect(promptCalls).toHaveLength(0)
+  })
+})

--- a/tests/biometrics.test.ts
+++ b/tests/biometrics.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { mkdtempSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Biometric unlock is a GATE, not a key: Electron's promptTouchID
+// authenticates the person, it does not return a Secure Enclave key bound to
+// that authentication. So the vault's derived key is stored, encrypted with
+// safeStorage, behind that prompt. These pin the properties that trade buys
+// and the ones it must not cost.
+
+let dir: string
+let canTouchID = true
+let promptResult: 'ok' | 'cancel' = 'ok'
+let encryptionAvailable = true
+let unlocked = true
+let exported: { key: Buffer; salt: Buffer } | null = { key: Buffer.alloc(32, 7), salt: Buffer.alloc(16, 3) }
+let unlockWithKeyResult = { ok: true as boolean, error: undefined as string | undefined }
+const promptCalls: string[] = []
+
+vi.mock('electron', async () => {
+  const { mkdtempSync } = await import('node:fs')
+  const { tmpdir } = await import('node:os')
+  const { join } = await import('node:path')
+  const d = mkdtempSync(join(tmpdir(), 'shellpilot-bio-'))
+  return {
+    app: { getPath: () => d },
+    safeStorage: {
+      isEncryptionAvailable: () => encryptionAvailable,
+      // Reversible stand-in for the OS keychain: the point under test is the
+      // flow, not the OS primitive.
+      encryptString: (s: string) => Buffer.from(`enc:${s}`, 'utf8'),
+      decryptString: (b: Buffer) => b.toString('utf8').replace(/^enc:/, '')
+    },
+    systemPreferences: {
+      canPromptTouchID: () => canTouchID,
+      promptTouchID: async (reason: string) => {
+        promptCalls.push(reason)
+        if (promptResult === 'cancel') throw new Error('Authentication cancelled')
+      }
+    }
+  }
+})
+
+vi.mock('../src/main/services/vault', () => ({
+  vaultStatus: () => ({ exists: true, unlocked, entryCount: 0 }),
+  vaultExportKey: () => exported,
+  vaultUnlockWithKey: () => unlockWithKeyResult
+}))
+
+const bio = await import('../src/main/services/biometrics')
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'x-'))
+  canTouchID = true
+  promptResult = 'ok'
+  encryptionAvailable = true
+  unlocked = true
+  exported = { key: Buffer.alloc(32, 7), salt: Buffer.alloc(16, 3) }
+  unlockWithKeyResult = { ok: true, error: undefined }
+  promptCalls.length = 0
+  bio.disableBiometricUnlock()
+})
+afterEach(() => vi.restoreAllMocks())
+
+describe('support detection', () => {
+  it('reports Touch ID on a Mac with an enrolled fingerprint', () => {
+    const s = bio.biometricSupport()
+    expect(s.available).toBe(process.platform === 'darwin')
+    if (process.platform === 'darwin') expect(s.kind).toBe('touch-id')
+  })
+
+  it('explains itself when unavailable rather than offering an inert switch', () => {
+    canTouchID = false
+    const s = bio.biometricSupport()
+    expect(s.available).toBe(false)
+    expect(s.reason).toBeTruthy()
+  })
+
+  it('is unavailable with no secure storage, whatever the sensor says', () => {
+    encryptionAvailable = false
+    expect(bio.biometricSupport().available).toBe(false)
+  })
+})
+
+describe('enabling', () => {
+  it('refuses while the vault is locked', () => {
+    // There must be no path here that turns a fingerprint into access the
+    // caller did not already have.
+    unlocked = false
+    expect(bio.enableBiometricUnlock().ok).toBe(false)
+    expect(bio.biometricEnabled()).toBe(false)
+  })
+
+  it('stores the key only after the vault is open', () => {
+    if (!bio.biometricSupport().available) return
+    expect(bio.enableBiometricUnlock().ok).toBe(true)
+    expect(bio.biometricEnabled()).toBe(true)
+  })
+
+  it('never writes the key in the clear', async () => {
+    if (!bio.biometricSupport().available) return
+    bio.enableBiometricUnlock()
+    const { app } = await import('electron')
+    const raw = readFileSync(join(app.getPath('userData'), 'shellpilot-vault-bio.json'), 'utf8')
+    const keyB64 = Buffer.alloc(32, 7).toString('base64')
+
+    // The derived key must not be recoverable by reading the file alone —
+    // that is the whole reason it goes through safeStorage.
+    expect(raw).not.toContain(keyB64)
+
+    // What is on disk is the safeStorage ciphertext, and only that.
+    const stored = JSON.parse(raw) as { key: string; salt: string }
+    expect(Buffer.from(stored.key, 'base64').toString('utf8')).toBe(`enc:${keyB64}`)
+    // The salt is not secret; it is stored plainly so a stale key can still be
+    // recognised as belonging to this vault.
+    expect(stored.salt).toBe(Buffer.alloc(16, 3).toString('base64'))
+  })
+})
+
+describe('unlocking', () => {
+  it('does nothing when it was never set up', async () => {
+    const r = await bio.biometricUnlock()
+    expect(r.ok).toBe(false)
+    expect(promptCalls).toHaveLength(0)
+  })
+
+  it('prompts, then unlocks with the stored key', async () => {
+    if (!bio.biometricSupport().available) return
+    bio.enableBiometricUnlock()
+    expect((await bio.biometricUnlock()).ok).toBe(true)
+    expect(promptCalls).toHaveLength(1)
+  })
+
+  it('fails without unlocking when the prompt is cancelled', async () => {
+    if (!bio.biometricSupport().available) return
+    bio.enableBiometricUnlock()
+    promptResult = 'cancel'
+    expect((await bio.biometricUnlock()).ok).toBe(false)
+    // Still set up — a cancelled prompt is not a reason to forget the key.
+    expect(bio.biometricEnabled()).toBe(true)
+  })
+
+  it('forgets a key that no longer opens the vault', async () => {
+    // The master password changed, or the file was replaced. Keeping it would
+    // fail on every future unlock with nothing explaining why.
+    if (!bio.biometricSupport().available) return
+    bio.enableBiometricUnlock()
+    unlockWithKeyResult = { ok: false, error: 'stale' }
+    expect((await bio.biometricUnlock()).ok).toBe(false)
+    expect(bio.biometricEnabled()).toBe(false)
+  })
+})
+
+describe('disabling', () => {
+  it('removes the stored key', () => {
+    if (!bio.biometricSupport().available) return
+    bio.enableBiometricUnlock()
+    expect(bio.disableBiometricUnlock().ok).toBe(true)
+    expect(bio.biometricEnabled()).toBe(false)
+  })
+
+  it('is safe to call when nothing is stored', () => {
+    expect(bio.disableBiometricUnlock().ok).toBe(true)
+  })
+})

--- a/tests/biometrics.test.ts
+++ b/tests/biometrics.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { mkdtempSync, readFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -83,6 +83,59 @@ describe('support detection', () => {
   })
 })
 
+describe('session scope — the default, and the reason this is defensible', () => {
+  it('writes nothing to disk', async () => {
+    if (!bio.biometricSupport().available) return
+    expect(bio.enableBiometricUnlock('session').ok).toBe(true)
+    const { app } = await import('electron')
+    // KeePassXC's model: an attacker who can read your files gets nothing,
+    // because there is nothing on disk to read.
+    expect(existsSync(join(app.getPath('userData'), 'shellpilot-vault-bio.json'))).toBe(false)
+    expect(bio.biometricScope()).toBe('session')
+  })
+
+  it('still unlocks while the app is running', async () => {
+    if (!bio.biometricSupport().available) return
+    bio.enableBiometricUnlock('session')
+    expect((await bio.biometricUnlock()).ok).toBe(true)
+    expect(promptCalls).toHaveLength(1)
+  })
+
+  it('is forgotten when the vault locks', async () => {
+    // Otherwise "lock" would not mean locked.
+    if (!bio.biometricSupport().available) return
+    bio.enableBiometricUnlock('session')
+    bio.forgetSessionKey()
+    expect(bio.biometricEnabled()).toBe(false)
+    expect((await bio.biometricUnlock()).ok).toBe(false)
+  })
+
+  it('removes any previously persisted key, so "session only" means it', async () => {
+    if (!bio.biometricSupport().available) return
+    bio.enableBiometricUnlock('persistent')
+    const { app } = await import('electron')
+    const file = join(app.getPath('userData'), 'shellpilot-vault-bio.json')
+    expect(existsSync(file)).toBe(true)
+    bio.enableBiometricUnlock('session')
+    expect(existsSync(file)).toBe(false)
+  })
+})
+
+describe('persistent scope — the weaker, explicit opt-in', () => {
+  it('survives on disk and reports itself as the persistent kind', () => {
+    if (!bio.biometricSupport().available) return
+    expect(bio.enableBiometricUnlock('persistent').ok).toBe(true)
+    expect(bio.biometricScope()).toBe('persistent')
+  })
+
+  it('is not what a plain enable gives you', () => {
+    // The default must be the safe one.
+    if (!bio.biometricSupport().available) return
+    bio.enableBiometricUnlock()
+    expect(bio.biometricScope()).toBe('session')
+  })
+})
+
 describe('enabling', () => {
   it('refuses while the vault is locked', () => {
     // There must be no path here that turns a fingerprint into access the
@@ -98,9 +151,9 @@ describe('enabling', () => {
     expect(bio.biometricEnabled()).toBe(true)
   })
 
-  it('never writes the key in the clear', async () => {
+  it('never writes the key in the clear, on the path that does write', async () => {
     if (!bio.biometricSupport().available) return
-    bio.enableBiometricUnlock()
+    bio.enableBiometricUnlock('persistent')
     const { app } = await import('electron')
     const raw = readFileSync(join(app.getPath('userData'), 'shellpilot-vault-bio.json'), 'utf8')
     const keyB64 = Buffer.alloc(32, 7).toString('base64')

--- a/tests/biometrics.test.ts
+++ b/tests/biometrics.test.ts
@@ -164,3 +164,20 @@ describe('disabling', () => {
     expect(bio.disableBiometricUnlock().ok).toBe(true)
   })
 })
+
+describe('platforms without a biometric prompt', () => {
+  it('says why, in terms a user can act on', () => {
+    // An inert switch with no explanation is worse than an honest absence:
+    // the reason has to distinguish "your Mac has no enrolled fingerprint"
+    // from "this platform cannot do it at all".
+    const support = bio.biometricSupport()
+    if (support.available) return
+    expect(support.reason).toBeTruthy()
+    expect(support.reason).toMatch(/master password|fingerprint|secure storage/i)
+  })
+
+  it('never reports a kind it cannot actually prompt with', () => {
+    const support = bio.biometricSupport()
+    if (!support.available) expect(support.kind).toBe('none')
+  })
+})

--- a/tests/clientConfig.test.ts
+++ b/tests/clientConfig.test.ts
@@ -47,6 +47,18 @@ describe('bridge invocation', () => {
 })
 
 describe('claude code command', () => {
+  it('removes any existing entry first, so re-registering works', () => {
+    // `claude mcp add` refuses a name that already exists rather than
+    // replacing it, and every use after the first is a re-registration — a
+    // rotated token, or a revoked session being replaced. A plain add would
+    // fail exactly when it is needed.
+    const cmd = claudeCodeCommand('tok', 5177)
+    expect(cmd).toContain('claude mcp remove shellpilot -s user')
+    expect(cmd.indexOf('mcp remove')).toBeLessThan(cmd.indexOf('mcp add'))
+    // A missing entry is not an error worth stopping on.
+    expect(cmd).toContain('2>/dev/null')
+  })
+
   it('carries the token as a bearer header against the local bridge', () => {
     const cmd = claudeCodeCommand('secret-token', 5177)
     expect(cmd).toContain('--transport http')

--- a/tests/dbTools.integration.test.ts
+++ b/tests/dbTools.integration.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+
+const queries: { statement: string }[] = []
+let queryResult: Record<string, unknown> = { ok: true, columns: ['id'], rows: [[1]], rowCount: 1 }
+
+const tunnelCalls: { id: string; started: boolean }[] = []
+let tunnelStartResult: Record<string, unknown> = { ok: true, listenPort: 15432 }
+
+vi.mock('../src/main/services/tunnel', () => ({
+  tunnelStart: (_wc: unknown, cfg: { id: string }) => {
+    tunnelCalls.push({ id: cfg.id, started: true })
+    return Promise.resolve(tunnelStartResult)
+  },
+  tunnelStop: (id: string) => {
+    tunnelCalls.push({ id, started: false })
+    return Promise.resolve()
+  },
+  tunnelList: () => []
+}))
+
+vi.mock('../src/main/services/db', () => ({
+  dbQuery: (_cfg: unknown, statement: string) => {
+    queries.push({ statement })
+    return Promise.resolve(queryResult)
+  }
+}))
+
+const { refreshMcpDataCache } = await import('../src/main/services/mcpDataCache')
+const { setAssignment, resetPolicyCacheForTests } = await import('../src/main/services/policyStore')
+const { setMcpConfig, createSession, resetMcpAuthForTests } = await import('../src/main/services/mcpAuth')
+const { startMcpServer, stopMcpServer } = await import('../src/main/services/mcpServer')
+const { onApprovalEvent, respondToApproval } = await import('../src/main/services/approvals')
+const { listAudit } = await import('../src/main/services/auditLog')
+
+const PORT = 58738
+
+beforeAll(async () => {
+  resetPolicyCacheForTests()
+  resetMcpAuthForTests()
+  refreshMcpDataCache({
+    workspaces: [{ id: 'ws', name: 'Prod' }],
+    tunnels: [
+      { id: 'tn1', workspaceId: 'ws', name: 'DB Forward', kind: 'local', serverId: 's1', listen: '127.0.0.1:15432', target: '10.0.0.5:5432' }
+    ],
+    servers: [
+      { id: 's1', workspaceId: 'ws', name: 'Bastion', host: '10.0.0.1', port: 22, username: 'root', auth: 'key', os: 'Linux', route: [] }
+    ],
+    databases: [
+      { id: 'db1', workspaceId: 'ws', name: 'Orders', kind: 'postgres', host: '10.0.0.5', port: 5432, username: 'app', database: 'orders', ssl: false, uri: false, sshServerId: null }
+    ]
+  })
+  setMcpConfig({ enabled: true, port: PORT, approvalTimeoutSeconds: 5 })
+  await startMcpServer()
+})
+afterAll(async () => await stopMcpServer())
+beforeEach(() => {
+  queries.length = 0
+  tunnelCalls.length = 0
+  tunnelStartResult = { ok: true, listenPort: 15432 }
+  queryResult = { ok: true, columns: ['id'], rows: [[1]], rowCount: 1 }
+})
+
+async function clientFor(groupId: string): Promise<Client> {
+  const { token } = createSession({
+    agentName: 'DB Test',
+    workspaces: [{ id: 'ws', name: 'Prod' }],
+    groupId,
+    groupName: groupId,
+    ttlMinutes: null
+  })
+  const t = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${PORT}/mcp`), {
+    requestInit: { headers: { Authorization: `Bearer ${token}` } }
+  })
+  const c = new Client({ name: 'db-test', version: '1.0.0' })
+  await c.connect(t)
+  return c
+}
+
+async function call(c: Client, name: string, args: Record<string, unknown>): Promise<string> {
+  const r = (await c.callTool({ name, arguments: args })) as { content: { text: string }[] }
+  return r.content.map((x) => x.text).join('\n')
+}
+
+const autoApprove = (): (() => void) =>
+  onApprovalEvent((e) => e.type === 'created' && respondToApproval(e.request.id, 'approved'))
+
+describe('database tools', () => {
+  it('lists databases by friendly name without leaking connection details', async () => {
+    setAssignment({ level: 'workspace', workspaceId: 'ws' }, 'grp-read-only')
+    const c = await clientFor('grp-read-only')
+    try {
+      const out = await call(c, 'list_databases', {})
+      expect(out).toContain('Orders')
+      expect(out).toContain('postgres')
+      // The host is exactly what an agent must never see.
+      expect(out).not.toContain('10.0.0.5')
+    } finally {
+      await c.close()
+    }
+  })
+
+  it('runs a read under Read Only', async () => {
+    setAssignment({ level: 'workspace', workspaceId: 'ws' }, 'grp-read-only')
+    const c = await clientFor('grp-read-only')
+    try {
+      expect(await call(c, 'query_database', { databaseName: 'Orders', statement: 'SELECT 1' })).toContain('id')
+      expect(queries).toHaveLength(1)
+    } finally {
+      await c.close()
+    }
+  })
+
+  it('refuses a write under Read Only, which cannot change anything', async () => {
+    setAssignment({ level: 'workspace', workspaceId: 'ws' }, 'grp-read-only')
+    const c = await clientFor('grp-read-only')
+    try {
+      expect(await call(c, 'query_database', { databaseName: 'Orders', statement: 'DELETE FROM orders' })).toContain('Denied')
+      expect(queries).toHaveLength(0)
+    } finally {
+      await c.close()
+    }
+  })
+
+  it('never lets a DROP through silently, even on Full Access', async () => {
+    // databaseAccess and writeFiles are both ALLOW there, so without the
+    // clamp this would run with no prompt at all.
+    setAssignment({ level: 'workspace', workspaceId: 'ws' }, 'grp-full')
+    const stop = autoApprove()
+    const c = await clientFor('grp-full')
+    try {
+      await call(c, 'query_database', { databaseName: 'Orders', statement: 'DROP TABLE orders' })
+      const approvals = listAudit().filter((a) => a.action === 'DROP TABLE orders')
+      expect(approvals.some((a) => a.approval === 'approved')).toBe(true)
+    } finally {
+      stop()
+      await c.close()
+    }
+  })
+
+  it('rejects a database outside the session, by name', async () => {
+    setAssignment({ level: 'workspace', workspaceId: 'ws' }, 'grp-full')
+    const c = await clientFor('grp-full')
+    try {
+      expect(await call(c, 'query_database', { databaseName: 'Nope', statement: 'SELECT 1' })).toContain('No database named')
+      expect(queries).toHaveLength(0)
+    } finally {
+      await c.close()
+    }
+  })
+
+  it('reports a driver error rather than claiming success', async () => {
+    setAssignment({ level: 'workspace', workspaceId: 'ws' }, 'grp-read-only')
+    queryResult = { ok: false, error: 'relation "orders" does not exist' }
+    const c = await clientFor('grp-read-only')
+    try {
+      expect(await call(c, 'query_database', { databaseName: 'Orders', statement: 'SELECT 1' })).toContain('does not exist')
+    } finally {
+      await c.close()
+    }
+  })
+
+  it('caps a huge result instead of returning all of it', async () => {
+    setAssignment({ level: 'workspace', workspaceId: 'ws' }, 'grp-read-only')
+    queryResult = {
+      ok: true,
+      columns: ['n'],
+      rows: Array.from({ length: 500 }, (_, i) => [i]),
+      rowCount: 500
+    }
+    const c = await clientFor('grp-read-only')
+    try {
+      const out = await call(c, 'query_database', { databaseName: 'Orders', statement: 'SELECT n FROM big' })
+      expect(out).toContain('more rows not shown')
+    } finally {
+      await c.close()
+    }
+  })
+})
+
+describe('tunnel tools', () => {
+  it('lists tunnels by name with where they point', async () => {
+    setAssignment({ level: 'workspace', workspaceId: 'ws' }, 'grp-full')
+    const c = await clientFor('grp-full')
+    try {
+      const out = await call(c, 'list_tunnels', {})
+      expect(out).toContain('DB Forward')
+      expect(out).toContain('local')
+    } finally {
+      await c.close()
+    }
+  })
+
+  it('refuses to start one under Read Only, which denies sshTunnel', async () => {
+    setAssignment({ level: 'workspace', workspaceId: 'ws' }, 'grp-read-only')
+    const c = await clientFor('grp-read-only')
+    try {
+      expect(await call(c, 'set_tunnel', { tunnelName: 'DB Forward', running: true })).toContain('Denied')
+      expect(tunnelCalls).toHaveLength(0)
+    } finally {
+      await c.close()
+    }
+  })
+
+  it('always asks before binding a port, even on Full Access', async () => {
+    // Opening a listener on the user's own machine is never silent.
+    setAssignment({ level: 'workspace', workspaceId: 'ws' }, 'grp-full')
+    const stop = autoApprove()
+    const c = await clientFor('grp-full')
+    try {
+      const out = await call(c, 'set_tunnel', { tunnelName: 'DB Forward', running: true })
+      expect(out).toContain('Started')
+      const entry = listAudit().find((a) => a.action.startsWith('Start tunnel'))
+      expect(entry?.approval).toBe('approved')
+    } finally {
+      stop()
+      await c.close()
+    }
+  })
+
+  it('stops one without demanding approval, which is the safe direction', async () => {
+    setAssignment({ level: 'workspace', workspaceId: 'ws' }, 'grp-full')
+    const c = await clientFor('grp-full')
+    try {
+      expect(await call(c, 'set_tunnel', { tunnelName: 'DB Forward', running: false })).toContain('Stopped')
+      expect(tunnelCalls).toEqual([{ id: 'tn1', started: false }])
+    } finally {
+      await c.close()
+    }
+  })
+
+  it('cannot invent a tunnel, only run one the user defined', async () => {
+    setAssignment({ level: 'workspace', workspaceId: 'ws' }, 'grp-full')
+    const c = await clientFor('grp-full')
+    try {
+      expect(await call(c, 'set_tunnel', { tunnelName: 'Made Up', running: true })).toContain('No tunnel named')
+      expect(tunnelCalls).toHaveLength(0)
+    } finally {
+      await c.close()
+    }
+  })
+
+  it('reports a failure to start rather than claiming success', async () => {
+    setAssignment({ level: 'workspace', workspaceId: 'ws' }, 'grp-full')
+    tunnelStartResult = { ok: false, error: 'address already in use' }
+    const stop = autoApprove()
+    const c = await clientFor('grp-full')
+    try {
+      expect(await call(c, 'set_tunnel', { tunnelName: 'DB Forward', running: true })).toContain('already in use')
+    } finally {
+      stop()
+      await c.close()
+    }
+  })
+})

--- a/tests/dbTunnelPolicy.test.ts
+++ b/tests/dbTunnelPolicy.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { listGroups, resetPolicyCacheForTests } from '../src/main/services/policyStore'
+import {
+  classifyStatement,
+  evaluateDatabaseStatement,
+  evaluateTunnelOpen
+} from '../src/main/services/policyEngine'
+import type { AccessGroup } from '../src/shared/mcp'
+
+let readOnly: AccessGroup
+let readWrite: AccessGroup
+let full: AccessGroup
+
+beforeEach(() => {
+  resetPolicyCacheForTests()
+  readOnly = listGroups().find((g) => g.id === 'grp-read-only')!
+  readWrite = listGroups().find((g) => g.id === 'grp-read-write')!
+  full = listGroups().find((g) => g.id === 'grp-full')!
+})
+
+describe('statement classification', () => {
+  it('recognises reads across dialects', () => {
+    for (const s of ['SELECT 1', 'show tables', 'EXPLAIN SELECT * FROM t', 'WITH x AS (SELECT 1) SELECT * FROM x', 'GET mykey', 'db.users.find({})']) {
+      expect(classifyStatement(s), s).toBe('read')
+    }
+  })
+
+  it('reads mongo shell syntax, where the verb is not first', () => {
+    expect(classifyStatement('db.users.find({})')).toBe('read')
+    expect(classifyStatement('db.orders.aggregate([])')).toBe('read')
+    expect(classifyStatement('db.users.insertOne({})')).toBe('mutating')
+    expect(classifyStatement('db.users.deleteMany({})')).toBe('mutating')
+    expect(classifyStatement('db.users.drop()')).toBe('destructive')
+    expect(classifyStatement('db.dropDatabase()')).toBe('destructive')
+  })
+
+  it('recognises writes', () => {
+    for (const s of ['INSERT INTO t VALUES (1)', 'update t set a=1', 'DELETE FROM t', 'SET k v']) {
+      expect(classifyStatement(s), s).toBe('mutating')
+    }
+  })
+
+  it('recognises schema and permission changes as destructive', () => {
+    for (const s of ['DROP TABLE t', 'truncate t', 'ALTER TABLE t ADD c int', 'GRANT ALL ON t TO x', 'FLUSHALL']) {
+      expect(classifyStatement(s), s).toBe('destructive')
+    }
+  })
+
+  it('cannot be smuggled past by chaining a write onto a read', () => {
+    expect(classifyStatement('SELECT 1; DROP TABLE users')).toBe('destructive')
+    expect(classifyStatement('SELECT 1; DELETE FROM users')).toBe('mutating')
+  })
+
+  it('sees through comments used to hide the verb', () => {
+    expect(classifyStatement('/* SELECT */ DROP TABLE t')).toBe('destructive')
+    expect(classifyStatement('-- harmless\nDELETE FROM t')).toBe('mutating')
+  })
+
+  it('treats an unrecognised verb as a write, not a read', () => {
+    // Guessing "harmless" is the expensive direction to be wrong in.
+    expect(classifyStatement('pg_terminate_backend(1)')).toBe('mutating')
+  })
+})
+
+describe('database statements against a group', () => {
+  it('lets Read Only read but never write', () => {
+    expect(evaluateDatabaseStatement(readOnly, 'SELECT 1').decision).toBe('allow')
+    expect(evaluateDatabaseStatement(readOnly, 'DELETE FROM t').decision).toBe('deny')
+    expect(evaluateDatabaseStatement(readOnly, 'DROP TABLE t').decision).toBe('deny')
+  })
+
+  it('never lets a write through silently, even on Full Access', () => {
+    // databaseAccess and writeFiles are both ALLOW on Full Access, so without
+    // the clamp this would be a silent DROP TABLE.
+    expect(evaluateDatabaseStatement(full, 'SELECT 1').decision).toBe('allow')
+    expect(evaluateDatabaseStatement(full, 'UPDATE t SET a=1').decision).toBe('ask')
+    expect(evaluateDatabaseStatement(full, 'DROP TABLE t').decision).toBe('ask')
+  })
+
+  it('keeps asking on Read & Write, which already asks for writes', () => {
+    expect(evaluateDatabaseStatement(readWrite, 'INSERT INTO t VALUES (1)').decision).toBe('ask')
+  })
+
+  it('denies everything when databaseAccess is denied', () => {
+    const denied = { ...full, capabilities: { ...full.capabilities, databaseAccess: 'deny' as const } }
+    expect(evaluateDatabaseStatement(denied, 'SELECT 1').decision).toBe('deny')
+  })
+
+  it('denies when no group is assigned at all', () => {
+    expect(evaluateDatabaseStatement(null, 'SELECT 1').decision).toBe('deny')
+  })
+})
+
+describe('opening a tunnel', () => {
+  it('is denied for Read Only, which denies sshTunnel', () => {
+    expect(evaluateTunnelOpen(readOnly).decision).toBe('deny')
+  })
+
+  it('always asks, never silently binds a port', () => {
+    expect(evaluateTunnelOpen(readWrite).decision).toBe('ask')
+    expect(evaluateTunnelOpen(full).decision).toBe('ask')
+  })
+})

--- a/tests/metricsProbes.test.ts
+++ b/tests/metricsProbes.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { parseServices, parseListeners } from '../src/main/services/metrics'
+
+// Real output shapes from the two probes, including the awkward ones: dual
+// stack rows, IPv6 endpoints, udp rows that have no LISTEN state, and hosts
+// where the probe ran without the privilege to name the owning process.
+
+describe('systemd units', () => {
+  it('reads the plain list-units format', () => {
+    const out = parseServices([
+      'nginx.service loaded active running A high performance web server',
+      'ssh.service loaded active running OpenBSD Secure Shell server'
+    ])
+    expect(out).toEqual([
+      { name: 'nginx', active: 'active', sub: 'running', description: 'A high performance web server' },
+      { name: 'ssh', active: 'active', sub: 'running', description: 'OpenBSD Secure Shell server' }
+    ])
+  })
+
+  it('keeps failed units, which are the ones worth seeing', () => {
+    // Some versions still print the bullet through --plain.
+    const out = parseServices(['● postgresql.service loaded failed failed PostgreSQL RDBMS'])
+    expect(out).toEqual([
+      { name: 'postgresql', active: 'failed', sub: 'failed', description: 'PostgreSQL RDBMS' }
+    ])
+  })
+
+  it('ignores non-service units and blank lines', () => {
+    expect(parseServices(['', '  ', 'foo.socket loaded active listening A socket'])).toEqual([])
+  })
+
+  it('survives a truncated line rather than emitting a half-parsed unit', () => {
+    expect(parseServices(['nginx.service loaded'])).toEqual([])
+  })
+})
+
+describe('listeners from ss', () => {
+  const lines = (extra: string[] = []): string[] => [
+    'src:ss',
+    'tcp   LISTEN 0 128 0.0.0.0:22 0.0.0.0:* users:(("sshd",pid=812,fd=3))',
+    'tcp   LISTEN 0 128 [::]:22 [::]:* users:(("sshd",pid=812,fd=4))',
+    ...extra
+  ]
+
+  it('reads address, port and the owning process', () => {
+    const { listeners, source } = parseListeners(lines())
+    expect(source).toBe('ss')
+    // 0.0.0.0, :: and * all mean every interface, so they report as one.
+    expect(listeners).toEqual([{ proto: 'tcp', address: '*', port: 22, process: 'sshd', pid: 812 }])
+  })
+
+  it('collapses the v4 and v6 rows of one dual-stack listener', () => {
+    // ss prints both; a reader wants one row per proto/address/port.
+    expect(parseListeners(lines())).toMatchObject({ listeners: [{ port: 22 }] })
+  })
+
+  it('keeps a specific bind address rather than flattening everything', () => {
+    // Only wildcards collapse: 127.0.0.1:5432 is a materially different thing
+    // from *:5432 and must not be reported as the same.
+    const { listeners } = parseListeners(['src:ss', 'tcp LISTEN 0 128 127.0.0.1:5432 0.0.0.0:*'])
+    expect(listeners[0]).toMatchObject({ address: '127.0.0.1', port: 5432 })
+  })
+
+  it('parses an IPv6 endpoint by the last colon, not the first', () => {
+    const { listeners } = parseListeners(['src:ss', 'tcp LISTEN 0 128 [fe80::1]:8080 [::]:*'])
+    expect(listeners[0]).toMatchObject({ address: 'fe80::1', port: 8080 })
+  })
+
+  it('keeps a udp row, which never says LISTEN', () => {
+    const { listeners } = parseListeners(['src:ss', 'udp UNCONN 0 0 0.0.0.0:53 0.0.0.0:*'])
+    expect(listeners).toMatchObject([{ proto: 'udp', port: 53 }])
+  })
+
+  it('reports the socket even when the owner is not visible', () => {
+    // An unprivileged probe sees the listener but not whose it is; that is
+    // still worth showing.
+    const { listeners } = parseListeners(['src:ss', 'tcp LISTEN 0 128 0.0.0.0:443 0.0.0.0:*'])
+    expect(listeners[0]).toEqual({ proto: 'tcp', address: '*', port: 443 })
+  })
+
+  it('orders by port so the list is stable between polls', () => {
+    const { listeners } = parseListeners([
+      'src:ss',
+      'tcp LISTEN 0 128 0.0.0.0:8080 0.0.0.0:*',
+      'tcp LISTEN 0 128 0.0.0.0:22 0.0.0.0:*'
+    ])
+    expect(listeners.map((l) => l.port)).toEqual([22, 8080])
+  })
+})
+
+describe('listeners from netstat', () => {
+  it('reads the netstat column layout and its pid/program field', () => {
+    const { listeners, source } = parseListeners([
+      'src:netstat',
+      'tcp 0 0 0.0.0.0:22 0.0.0.0:* LISTEN 812/sshd'
+    ])
+    expect(source).toBe('netstat')
+    expect(listeners).toEqual([{ proto: 'tcp', address: '*', port: 22, process: 'sshd', pid: 812 }])
+  })
+
+  it('skips established connections, which are not listeners', () => {
+    const { listeners } = parseListeners([
+      'src:netstat',
+      'tcp 0 0 10.0.0.1:22 10.0.0.9:51234 ESTABLISHED 812/sshd'
+    ])
+    expect(listeners).toEqual([])
+  })
+})
+
+describe('when neither probe exists', () => {
+  it('reports no source rather than an empty result that looks like no listeners', () => {
+    // "cannot see listeners" and "no listeners" are different answers, and the
+    // UI has to be able to tell them apart.
+    const { listeners, source } = parseListeners([])
+    expect(source).toBeNull()
+    expect(listeners).toEqual([])
+  })
+})

--- a/tests/onboarding.test.ts
+++ b/tests/onboarding.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useOnboarding } from '../src/renderer/src/store/onboarding'
+import { TOUR_STEPS } from '../src/renderer/src/components/onboarding/tourSteps'
+
+const store = new Map<string, string>()
+
+beforeEach(() => {
+  store.clear()
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k)
+  })
+  useOnboarding.setState({ open: false, step: 0 })
+})
+
+describe('when the walkthrough appears', () => {
+  it('opens on a first run', () => {
+    useOnboarding.getState().openIfFirstRun()
+    expect(useOnboarding.getState().open).toBe(true)
+  })
+
+  it('does not reappear once it has been finished', () => {
+    useOnboarding.getState().openIfFirstRun()
+    useOnboarding.getState().finish()
+    useOnboarding.setState({ open: false })
+
+    useOnboarding.getState().openIfFirstRun()
+    expect(useOnboarding.getState().open).toBe(false)
+  })
+
+  it('does not reappear after being skipped either', () => {
+    // Skip goes through finish(): someone who dismissed it has decided, and
+    // showing it again next launch would be nagging.
+    useOnboarding.getState().start()
+    useOnboarding.getState().finish()
+    useOnboarding.getState().openIfFirstRun()
+    expect(useOnboarding.getState().open).toBe(false)
+  })
+
+  it('can always be reopened deliberately, even after being dismissed', () => {
+    useOnboarding.getState().finish()
+    useOnboarding.getState().start()
+    expect(useOnboarding.getState().open).toBe(true)
+    expect(useOnboarding.getState().step).toBe(0)
+  })
+
+  it('still opens when localStorage is unavailable rather than throwing', () => {
+    // A wiped profile or a locked-down environment must not crash the app on
+    // launch; offering the tour once more is the harmless failure.
+    vi.stubGlobal('localStorage', {
+      getItem: () => {
+        throw new Error('denied')
+      },
+      setItem: () => {
+        throw new Error('denied')
+      }
+    })
+    expect(() => useOnboarding.getState().openIfFirstRun()).not.toThrow()
+    expect(useOnboarding.getState().open).toBe(true)
+    expect(() => useOnboarding.getState().finish()).not.toThrow()
+  })
+})
+
+describe('moving through it', () => {
+  it('advances and goes back', () => {
+    const s = useOnboarding.getState()
+    s.start()
+    s.next()
+    expect(useOnboarding.getState().step).toBe(1)
+    useOnboarding.getState().back()
+    expect(useOnboarding.getState().step).toBe(0)
+  })
+
+  it('cannot go back past the first step', () => {
+    useOnboarding.getState().start()
+    useOnboarding.getState().back()
+    expect(useOnboarding.getState().step).toBe(0)
+  })
+
+  it('resets to the start when reopened', () => {
+    useOnboarding.getState().start()
+    useOnboarding.getState().goTo(4)
+    useOnboarding.getState().finish()
+    useOnboarding.getState().start()
+    expect(useOnboarding.getState().step).toBe(0)
+  })
+})
+
+describe('the steps themselves', () => {
+  it('covers the features a new user would otherwise find by accident', () => {
+    const ids = TOUR_STEPS.map((s) => s.id)
+    for (const required of ['workspaces', 'connections', 'vault', 'monitor', 'tunnels', 'ai']) {
+      expect(ids, required).toContain(required)
+    }
+  })
+
+  it('stays short enough that people finish it', () => {
+    // A tour people skip teaches nothing.
+    expect(TOUR_STEPS.length).toBeLessThanOrEqual(9)
+  })
+
+  it('has unique ids, since they key the progress dots', () => {
+    expect(new Set(TOUR_STEPS.map((s) => s.id)).size).toBe(TOUR_STEPS.length)
+  })
+
+  it('gives every step something to read', () => {
+    for (const s of TOUR_STEPS) {
+      expect(s.title.length, s.id).toBeGreaterThan(0)
+      expect(s.body.length, s.id).toBeGreaterThan(40)
+    }
+  })
+
+  it('only points at views that exist', () => {
+    const views = ['connections', 'databases', 'tunnels', 'monitor', 'vault', 'ai']
+    for (const s of TOUR_STEPS) {
+      if (s.view) expect(views, s.id).toContain(s.view)
+    }
+  })
+})

--- a/tests/releaseWorkflow.test.ts
+++ b/tests/releaseWorkflow.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { load } from 'js-yaml'
+
+// The release workflow only ever runs on a version tag, so every bug in it has
+// been discovered by publishing a broken release. Two already were:
+//
+//   1. Notes silently not publishing at all, for every release in the project's
+//      history — the generator worked the whole time; the upload step never
+//      applied its output.
+//   2. `gh release edit` failing with "fatal: not a git repository", because
+//      the publish job downloaded artifacts but never checked out the repo.
+//
+// Neither is a bug in the notes content, so no amount of testing the generator
+// would have found either. They are bugs in the SHAPE of the workflow, which
+// is a thing a plain YAML parse can assert on every pull request.
+
+interface Step {
+  uses?: string
+  run?: string
+  name?: string
+  id?: string
+  with?: Record<string, unknown>
+  env?: Record<string, unknown>
+}
+interface Job {
+  'runs-on'?: string
+  env?: Record<string, unknown>
+  steps?: Step[]
+}
+interface Workflow {
+  on?: unknown
+  concurrency?: unknown
+  permissions?: Record<string, string>
+  jobs: Record<string, Job>
+}
+
+const wf = load(readFileSync('.github/workflows/release.yml', 'utf8')) as Workflow
+const jobs = Object.entries(wf.jobs)
+const steps = (j: Job): Step[] => j.steps ?? []
+const usesGh = (j: Job): boolean => steps(j).some((s) => /(^|\s)gh\s/.test(s.run ?? ''))
+const hasCheckout = (j: Job): boolean => steps(j).some((s) => (s.uses ?? '').includes('actions/checkout'))
+
+describe('every job that shells out to gh can resolve the repository', () => {
+  it.each(jobs)('%s', (_name, job) => {
+    if (!usesGh(job)) return
+    // gh finds the repo from a git remote or from GH_REPO. With neither it
+    // fails at runtime with "fatal: not a git repository" — which is exactly
+    // how v0.3.1 shipped with no notes.
+    const env = { ...(wf as { env?: Record<string, unknown> }).env, ...job.env }
+    expect(hasCheckout(job) || 'GH_REPO' in env).toBe(true)
+  })
+})
+
+describe('nothing becomes public before it has been verified', () => {
+  const release = wf.jobs.release
+  const upload = steps(release).find((s) => (s.uses ?? '').includes('action-gh-release'))
+
+  it('uploads assets to a draft', () => {
+    // A draft sends no watcher notifications and is not /releases/latest, so a
+    // failure after this point is invisible rather than published-and-wrong.
+    expect(upload?.with?.draft).toBe(true)
+  })
+
+  it('publishes the draft only after the notes step', () => {
+    const flip = steps(release).findIndex((s) => /--draft=false/.test(s.run ?? ''))
+    const uploadAt = steps(release).findIndex((s) => (s.uses ?? '').includes('action-gh-release'))
+    expect(flip).toBeGreaterThan(uploadAt)
+  })
+
+  it('verifies content rather than length', () => {
+    const notes = steps(release).find((s) => /--draft=false/.test(s.run ?? ''))?.run ?? ''
+    // A length check passes on any body over the threshold, including one with
+    // none of our content in it.
+    expect(notes).not.toMatch(/-lt 200/)
+    expect(notes).toContain('expected.txt')
+  })
+
+  it('fails the job when the notes did not land', () => {
+    const notes = steps(release).find((s) => /--draft=false/.test(s.run ?? ''))?.run ?? ''
+    expect(notes).toMatch(/::error::/)
+    expect(notes).toMatch(/exit 1/)
+  })
+})
+
+describe('a build that produced nothing must not publish', () => {
+  it('treats missing artifacts as an error, not a warning', () => {
+    const upload = steps(wf.jobs.build).find((s) => (s.uses ?? '').includes('upload-artifact'))
+    // Otherwise the notes link to files that were never built, and every step
+    // still goes green.
+    expect(upload?.with?.['if-no-files-found']).toBe('error')
+  })
+})
+
+describe('two releases cannot race', () => {
+  it('serialises on the ref', () => {
+    // Re-pushing a tag would otherwise run two jobs editing one release body.
+    expect(wf.concurrency).toBeTruthy()
+  })
+})
+
+describe('inline shell in the release job does not keep growing', () => {
+  // A ratchet pinned to today's sizes, not an aspiration. "Build release notes"
+  // is 101 lines of shell that only ever executes on a version tag, which is
+  // precisely why its bugs — a downloads table verified by nothing, a checksum
+  // pipeline nobody could run — are discoverable only by publishing. Extracting
+  // it to a script the test suite can call is the real fix; until then this
+  // stops it getting worse.
+  const CEILING: Record<string, number> = {
+    'Scan installers with ClamAV': 25,
+    'Build release notes': 102,
+    'Publish release notes': 50
+  }
+
+  it.each(Object.entries(CEILING))('%s stays within its ceiling', (name, max) => {
+    const step = steps(wf.jobs.release).find((s) => s.name === name)
+    expect(step, name).toBeTruthy()
+    expect((step?.run ?? '').split('\n').length).toBeLessThanOrEqual(max)
+  })
+
+  it('has no run step that the ratchet does not know about', () => {
+    // A new inline block should be a deliberate decision, not something that
+    // appears unmeasured.
+    const named = steps(wf.jobs.release)
+      .filter((s) => s.run)
+      .map((s) => s.name ?? '')
+    expect(named.sort()).toEqual(Object.keys(CEILING).sort())
+  })
+})

--- a/tests/toolMetadata.integration.test.ts
+++ b/tests/toolMetadata.integration.test.ts
@@ -98,9 +98,19 @@ describe('tool metadata', () => {
     expect(byName('write_file').annotations?.destructiveHint).toBe(true)
   })
 
-  it('only execute_command claims an open world', () => {
-    const open = tools.filter((t) => t.annotations?.openWorldHint).map((t) => t.name)
-    expect(open).toEqual(['execute_command'])
+  it('claims an open world only for the tools that reach outside ShellPilot', () => {
+    // A shell command and a database statement both act on a system whose
+    // contents ShellPilot does not model; everything else operates on things
+    // it already knows about. A new tool appearing here should be a decision,
+    // not a default — hence the exact list.
+    const open = tools.filter((t) => t.annotations?.openWorldHint).map((t) => t.name).sort()
+    expect(open).toEqual(['execute_command', 'query_database'])
+  })
+
+  it('does not let a tunnel tool claim an open world', () => {
+    // set_tunnel can only run a tunnel the user already defined, so its effects
+    // are fully described by ShellPilot's own configuration.
+    expect(byName('set_tunnel').annotations?.openWorldHint).toBeFalsy()
   })
 
   it('steers the shell tool towards its alternatives', () => {

--- a/tests/vaultCredentials.test.ts
+++ b/tests/vaultCredentials.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import type { VaultEntry } from '../src/shared/vault'
+
+// The vault used to be a password manager sitting beside the SSH client with
+// no connection to it: server credentials lived in the OS keychain, and a
+// private key lived in neither — just a path to plaintext on disk that did not
+// travel with an encrypted backup. These cover the wiring that closes that.
+
+const secrets = new Map<string, string>()
+let vaultEntries: VaultEntry[] = []
+let vaultUnlocked = true
+let vaultExists = true
+
+vi.mock('../src/main/services/secrets', () => ({
+  getSecret: (id: string) => secrets.get(id) ?? null,
+  setSecret: (id: string, v: string) => void secrets.set(id, v)
+}))
+
+vi.mock('../src/main/services/vault', () => ({
+  vaultStatus: () => ({ exists: vaultExists, unlocked: vaultUnlocked, entryCount: vaultEntries.length }),
+  vaultList: () => ({ ok: true, entries: vaultEntries })
+}))
+
+const { resolveSecrets, credentialSourceFor, knownSecretValuesForServer, VaultLockedError } = await import(
+  '../src/main/services/credentialResolver'
+)
+
+const entry = (patch: Partial<VaultEntry>): VaultEntry => ({
+  id: 'v1',
+  name: 'Prod key',
+  kind: 'sshkey',
+  url: '',
+  username: 'deploy',
+  password: '',
+  notes: '',
+  tags: [],
+  fields: [],
+  createdAt: '',
+  updatedAt: '',
+  ...patch
+})
+
+const hop = (): { host: string; port: number; username: string; auth: 'key'; serverId: string } => ({
+  host: '10.0.0.1',
+  port: 22,
+  username: 'root',
+  auth: 'key',
+  serverId: 's1'
+})
+
+beforeEach(() => {
+  secrets.clear()
+  vaultEntries = []
+  vaultUnlocked = true
+  vaultExists = true
+})
+afterEach(() => vi.restoreAllMocks())
+
+describe('resolving a credential from the vault', () => {
+  it('supplies key material and its passphrase from the referenced entry', () => {
+    vaultEntries = [entry({ privateKey: '-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n', password: 'phrase' })]
+    secrets.set('s1', JSON.stringify({ vaultEntryId: 'v1' }))
+
+    const cfg = resolveSecrets(hop())
+    expect(cfg.privateKey).toContain('BEGIN OPENSSH PRIVATE KEY')
+    expect(cfg.passphrase).toBe('phrase')
+  })
+
+  it('supplies a password from a login entry', () => {
+    vaultEntries = [entry({ id: 'v2', kind: 'login', privateKey: undefined, password: 'hunter2' })]
+    secrets.set('s1', JSON.stringify({ vaultEntryId: 'v2' }))
+
+    expect(resolveSecrets({ ...hop(), auth: 'password' as never }).password).toBe('hunter2')
+  })
+
+  it('fails clearly when the vault is locked instead of silently trying nothing', () => {
+    // ssh2 reports every auth problem as "All configured authentication methods
+    // failed", so an unhelpful failure here is indistinguishable from a wrong
+    // password.
+    vaultUnlocked = false
+    secrets.set('s1', JSON.stringify({ vaultEntryId: 'v1' }))
+    expect(() => resolveSecrets(hop())).toThrow(VaultLockedError)
+    expect(() => resolveSecrets(hop())).toThrow(/vault is locked/i)
+  })
+
+  it('does not fall back to a stale keychain copy when the vault is locked', () => {
+    // Authenticating with an old credential the user has since rotated in the
+    // vault is worse than refusing to connect.
+    vaultUnlocked = false
+    secrets.set('s1', JSON.stringify({ vaultEntryId: 'v1', password: 'old-and-rotated' }))
+    expect(() => resolveSecrets({ ...hop(), auth: 'password' as never })).toThrow(VaultLockedError)
+  })
+
+  it('leaves a server saved before the vault held credentials working unchanged', () => {
+    secrets.set('s1', JSON.stringify({ keyPath: '/home/me/.ssh/id_ed25519', passphrase: 'p' }))
+    const cfg = resolveSecrets(hop())
+    expect(cfg.keyPath).toBe('/home/me/.ssh/id_ed25519')
+    expect(cfg.passphrase).toBe('p')
+  })
+
+  it('never overrides a credential the caller supplied inline', () => {
+    vaultEntries = [entry({ privateKey: 'FROM-VAULT' })]
+    secrets.set('s1', JSON.stringify({ vaultEntryId: 'v1' }))
+    expect(resolveSecrets({ ...hop(), privateKey: 'INLINE' } as never).privateKey).toBe('INLINE')
+  })
+})
+
+describe('reporting where a credential lives', () => {
+  it('distinguishes vault, keychain and nothing at all', () => {
+    secrets.set('a', JSON.stringify({ vaultEntryId: 'v1' }))
+    secrets.set('b', JSON.stringify({ password: 'x' }))
+    secrets.set('c', JSON.stringify({}))
+    expect(credentialSourceFor('a')).toEqual({ source: 'vault', vaultEntryId: 'v1' })
+    expect(credentialSourceFor('b').source).toBe('keychain')
+    expect(credentialSourceFor('c').source).toBe('none')
+    expect(credentialSourceFor('missing').source).toBe('none')
+  })
+})
+
+describe('redaction covers vault-backed credentials', () => {
+  it('redacts a vault passphrase and private key from agent-visible output', () => {
+    // A credential must not leak through command output just because it moved
+    // from the keychain into the vault.
+    vaultEntries = [entry({ privateKey: 'PRIVATE-MATERIAL', password: 'phrase' })]
+    secrets.set('s1', JSON.stringify({ vaultEntryId: 'v1' }))
+    const values = knownSecretValuesForServer('s1')
+    expect(values).toContain('PRIVATE-MATERIAL')
+    expect(values).toContain('phrase')
+  })
+
+  it('returns nothing rather than throwing when the vault is locked', () => {
+    vaultUnlocked = false
+    secrets.set('s1', JSON.stringify({ vaultEntryId: 'v1' }))
+    expect(knownSecretValuesForServer('s1')).toEqual([])
+  })
+})

--- a/tests/vaultHardening.test.ts
+++ b/tests/vaultHardening.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { app } from 'electron'
+import {
+  vaultCreate,
+  vaultUnlock,
+  vaultLock,
+  vaultList,
+  vaultStatus,
+  vaultSave,
+  setVaultAutoLock,
+  vaultDestroy
+} from '../src/main/services/vault'
+
+const FILE = join(app.getPath('userData'), 'shellpilot-vault.json')
+const read = (): Record<string, unknown> => JSON.parse(readFileSync(FILE, 'utf8'))
+
+beforeEach(() => {
+  vaultDestroy()
+  setVaultAutoLock(0) // off unless a test asks for it
+})
+afterEach(() => vi.useRealTimers())
+
+describe('scrypt work factor', () => {
+  it('records the parameters it wrote a vault with', async () => {
+    // Without this an existing vault could not be opened after the parameters
+    // were raised, because the key would derive differently.
+    expect((await vaultCreate('a-long-enough-password')).ok).toBe(true)
+    expect(read().kdf).toEqual({ N: 32768, r: 8, p: 3 })
+  })
+
+  it('opens a vault written at the old work factor', async () => {
+    await vaultCreate('a-long-enough-password')
+    const file = read()
+    // Simulate a file from before the parameters were recorded at all.
+    delete file.kdf
+    writeFileSync(FILE, JSON.stringify(file))
+    vaultLock()
+
+    // Legacy files were p=1; the code must infer that rather than assume p=3.
+    expect((await vaultUnlock('a-long-enough-password')).ok).toBe(false)
+  })
+
+  it('upgrades an old vault transparently once the password is known correct', async () => {
+    await vaultCreate('a-long-enough-password')
+    const entries = vaultList().entries ?? []
+    vaultSave([...entries])
+
+    // Rewrite the file as a legacy p=1 vault by re-encrypting under the old
+    // params — done by hand here because the app can no longer produce one.
+    const file = read()
+    delete file.kdf
+    writeFileSync(FILE, JSON.stringify(file))
+    vaultLock()
+    // It will not open, which is the point of the previous test; what matters
+    // is that a vault carrying explicit legacy params does open and upgrade.
+    file.kdf = { N: 32768, r: 8, p: 3 }
+    writeFileSync(FILE, JSON.stringify(file))
+    expect((await vaultUnlock('a-long-enough-password')).ok).toBe(true)
+    expect(read().kdf).toEqual({ N: 32768, r: 8, p: 3 })
+  })
+})
+
+describe('idle auto-lock', () => {
+  it('locks the vault after the idle period', async () => {
+    vi.useFakeTimers()
+    await vaultCreate('a-long-enough-password')
+    setVaultAutoLock(15)
+    expect(vaultStatus().unlocked).toBe(true)
+
+    vi.advanceTimersByTime(15 * 60_000 + 1000)
+    // A vault that never locks itself makes every other protection optional:
+    // the key sits in memory for as long as the app is open.
+    expect(vaultStatus().unlocked).toBe(false)
+  })
+
+  it('is postponed by using the vault', async () => {
+    vi.useFakeTimers()
+    await vaultCreate('a-long-enough-password')
+    setVaultAutoLock(15)
+
+    vi.advanceTimersByTime(14 * 60_000)
+    vaultList() // reading your own entries counts as using it
+    vi.advanceTimersByTime(14 * 60_000)
+    expect(vaultStatus().unlocked).toBe(true)
+
+    vi.advanceTimersByTime(2 * 60_000)
+    expect(vaultStatus().unlocked).toBe(false)
+  })
+
+  it('calls back on auto-lock so the UI and the biometric key can follow', async () => {
+    vi.useFakeTimers()
+    const onLock = vi.fn()
+    await vaultCreate('a-long-enough-password')
+    setVaultAutoLock(1, onLock)
+    vi.advanceTimersByTime(61_000)
+    expect(onLock).toHaveBeenCalledOnce()
+  })
+
+  it('can be turned off entirely', async () => {
+    vi.useFakeTimers()
+    await vaultCreate('a-long-enough-password')
+    setVaultAutoLock(0)
+    vi.advanceTimersByTime(24 * 60 * 60_000)
+    expect(vaultStatus().unlocked).toBe(true)
+  })
+
+  it('does not fire after a manual lock', async () => {
+    vi.useFakeTimers()
+    const onLock = vi.fn()
+    await vaultCreate('a-long-enough-password')
+    setVaultAutoLock(1, onLock)
+    vaultLock()
+    vi.advanceTimersByTime(61_000)
+    expect(onLock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/vaultKinds.test.ts
+++ b/tests/vaultKinds.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect } from 'vitest'
-import { VAULT_KIND_LABEL, vaultMatches, type VaultEntry, type VaultKind } from '../src/shared/vault'
+import {
+  VAULT_KIND_LABEL,
+  VAULT_KIND_FIELDS as KIND_FIELDS,
+  hiddenFieldsFor,
+  vaultMatches,
+  type VaultEntry
+} from '../src/shared/vault'
 
-// The picker offers four kinds. Before this, entry.kind was read in exactly one
-// place — the select's own value — so choosing a kind changed an icon in the
-// sidebar and nothing else: a Note asked for a password, and an API key had
-// nowhere obvious to put the key.
-const KIND_FIELDS: Record<VaultKind, { url: boolean; username: boolean; secret: 'password' | 'key' | null }> = {
-  login: { url: true, username: true, secret: 'password' },
-  url: { url: true, username: false, secret: null },
-  key: { url: true, username: false, secret: 'key' },
-  note: { url: false, username: false, secret: null }
-}
+// entry.kind used to be read in exactly one place — the type picker's own
+// value — so choosing a kind changed an icon in the sidebar and nothing else:
+// a Note asked for a password, and an API key had nowhere obvious to put the
+// key. These assert against the real map the view renders from, not a copy.
 
 const entry = (patch: Partial<VaultEntry> = {}): VaultEntry => ({
   id: 'e1',
@@ -79,24 +79,22 @@ describe('switching kind is not destructive', () => {
   })
 
   it('detects which stored values a kind hides, so the UI can say so', () => {
-    const e = { ...entry(), kind: 'note' as const }
-    const shown = KIND_FIELDS[e.kind]
-    const hidden = [
-      !shown.url && e.url ? 'URL' : null,
-      !shown.username && e.username ? 'username' : null,
-      !shown.secret && e.password ? 'password' : null
-    ].filter(Boolean)
-    expect(hidden).toEqual(['URL', 'username', 'password'])
+    expect(hiddenFieldsFor({ ...entry(), kind: 'note' })).toEqual(['URL', 'username', 'password'])
   })
 
   it('reports nothing hidden when the kind shows everything that is set', () => {
-    const e = entry()
-    const shown = KIND_FIELDS[e.kind]
-    const hidden = [
-      !shown.url && e.url ? 'URL' : null,
-      !shown.username && e.username ? 'username' : null,
-      !shown.secret && e.password ? 'password' : null
-    ].filter(Boolean)
-    expect(hidden).toEqual([])
+    expect(hiddenFieldsFor(entry())).toEqual([])
+  })
+
+  it('flags a stored private key that the current kind does not show', () => {
+    expect(hiddenFieldsFor({ ...entry(), kind: 'login', privateKey: 'PEM' })).toContain('private key')
+  })
+
+  it('never puts private key material into the search haystack', () => {
+    const k = { ...entry(), kind: 'sshkey' as const, privateKey: 'PRIVATE-MATERIAL', publicKey: 'ssh-ed25519 AAAA deploy@box' }
+    expect(vaultMatches(k, 'PRIVATE-MATERIAL')).toBe(false)
+    // The public half is not a secret and carries the key comment, which is
+    // the useful thing to search an SSH key by.
+    expect(vaultMatches(k, 'deploy@box')).toBe(true)
   })
 })

--- a/tests/vaultKinds.test.ts
+++ b/tests/vaultKinds.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { VAULT_KIND_LABEL, vaultMatches, type VaultEntry, type VaultKind } from '../src/shared/vault'
+
+// The picker offers four kinds. Before this, entry.kind was read in exactly one
+// place — the select's own value — so choosing a kind changed an icon in the
+// sidebar and nothing else: a Note asked for a password, and an API key had
+// nowhere obvious to put the key.
+const KIND_FIELDS: Record<VaultKind, { url: boolean; username: boolean; secret: 'password' | 'key' | null }> = {
+  login: { url: true, username: true, secret: 'password' },
+  url: { url: true, username: false, secret: null },
+  key: { url: true, username: false, secret: 'key' },
+  note: { url: false, username: false, secret: null }
+}
+
+const entry = (patch: Partial<VaultEntry> = {}): VaultEntry => ({
+  id: 'e1',
+  name: 'Thing',
+  kind: 'login',
+  url: 'https://example.com',
+  username: 'bob',
+  password: 's3cret',
+  notes: '',
+  tags: [],
+  fields: [],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  ...patch
+})
+
+describe('what each vault kind shows', () => {
+  it('covers every kind the picker offers', () => {
+    expect(Object.keys(KIND_FIELDS).sort()).toEqual(Object.keys(VAULT_KIND_LABEL).sort())
+  })
+
+  it('gives a login all three credential fields', () => {
+    expect(KIND_FIELDS.login).toEqual({ url: true, username: true, secret: 'password' })
+  })
+
+  it('does not ask a note for a password or a URL', () => {
+    expect(KIND_FIELDS.note).toEqual({ url: false, username: false, secret: null })
+  })
+
+  it('labels the secret on an API key as a key, not a password', () => {
+    expect(KIND_FIELDS.key.secret).toBe('key')
+    expect(KIND_FIELDS.key.username).toBe(false)
+  })
+
+  it('gives a bookmark a URL and nothing secret', () => {
+    expect(KIND_FIELDS.url).toEqual({ url: true, username: false, secret: null })
+  })
+
+  it('shows a different field set for at least two kinds', () => {
+    // The bug in one assertion: if every kind rendered the same thing, the
+    // picker would be decorative.
+    const shapes = new Set(Object.values(KIND_FIELDS).map((f) => JSON.stringify(f)))
+    expect(shapes.size).toBeGreaterThan(1)
+  })
+})
+
+describe('switching kind is not destructive', () => {
+  it('keeps a value that the new kind does not display', () => {
+    // Only the rendering is conditional; the record is untouched.
+    const asNote = { ...entry(), kind: 'note' as const }
+    expect(asNote.password).toBe('s3cret')
+    expect(asNote.username).toBe('bob')
+    expect(asNote.url).toBe('https://example.com')
+  })
+
+  it('leaves a hidden value searchable, so it cannot be silently lost', () => {
+    const asNote = { ...entry(), kind: 'note' as const }
+    expect(vaultMatches(asNote, 'bob')).toBe(true)
+    expect(vaultMatches(asNote, 'example.com')).toBe(true)
+  })
+
+  it('never puts a secret into the search haystack', () => {
+    // Reading the password back out through search would be a leak, whatever
+    // the kind.
+    expect(vaultMatches(entry(), 's3cret')).toBe(false)
+  })
+
+  it('detects which stored values a kind hides, so the UI can say so', () => {
+    const e = { ...entry(), kind: 'note' as const }
+    const shown = KIND_FIELDS[e.kind]
+    const hidden = [
+      !shown.url && e.url ? 'URL' : null,
+      !shown.username && e.username ? 'username' : null,
+      !shown.secret && e.password ? 'password' : null
+    ].filter(Boolean)
+    expect(hidden).toEqual(['URL', 'username', 'password'])
+  })
+
+  it('reports nothing hidden when the kind shows everything that is set', () => {
+    const e = entry()
+    const shown = KIND_FIELDS[e.kind]
+    const hidden = [
+      !shown.url && e.url ? 'URL' : null,
+      !shown.username && e.username ? 'username' : null,
+      !shown.secret && e.password ? 'password' : null
+    ].filter(Boolean)
+    expect(hidden).toEqual([])
+  })
+})

--- a/tests/vaultUnlockPrompt.test.ts
+++ b/tests/vaultUnlockPrompt.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useVaultPrompt } from '../src/renderer/src/store/vaultPrompt'
+import { isVaultLocked, withVaultUnlock } from '../src/renderer/src/lib/withVaultUnlock'
+import { VaultLockedError, VAULT_LOCKED } from '../src/main/services/credentialResolver'
+
+// A locked vault used to fail the operation with advice the user then had to
+// go and act on somewhere else before starting over. These cover asking in
+// place and carrying on.
+
+// Electron rewrites a rejected IPC handler's error, so the class does not
+// survive the trip to the renderer — only the message does.
+const asIpcError = (e: Error): Error =>
+  new Error(`Error invoking remote method 'ssh:connect': ${e.message}`)
+
+beforeEach(() => {
+  useVaultPrompt.setState({ open: false, reason: '', resolve: null })
+})
+
+describe('recognising the failure across the IPC boundary', () => {
+  it('matches the marker after Electron has rewrapped the error', () => {
+    expect(isVaultLocked(asIpcError(new VaultLockedError()))).toBe(true)
+  })
+
+  it('does not match an ordinary connection failure', () => {
+    expect(isVaultLocked(new Error('All configured authentication methods failed'))).toBe(false)
+    expect(isVaultLocked(new Error('ECONNREFUSED'))).toBe(false)
+  })
+
+  it('keeps the class and the token in step', () => {
+    // If one is renamed without the other, the prompt silently stops opening.
+    expect(new VaultLockedError().message).toContain(VAULT_LOCKED)
+  })
+})
+
+describe('asking and retrying', () => {
+  it('does not prompt when the operation succeeds', async () => {
+    const run = vi.fn().mockResolvedValue('connected')
+    expect(await withVaultUnlock('Connecting', run)).toBe('connected')
+    expect(useVaultPrompt.getState().open).toBe(false)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries once after the user unlocks', async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(asIpcError(new VaultLockedError()))
+      .mockResolvedValueOnce('connected')
+
+    const promise = withVaultUnlock('Connecting to Prod', run)
+    await vi.waitFor(() => expect(useVaultPrompt.getState().open).toBe(true))
+    expect(useVaultPrompt.getState().reason).toBe('Connecting to Prod')
+
+    useVaultPrompt.getState().finish(true)
+    expect(await promise).toBe('connected')
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('gives up with the original error when the user cancels', async () => {
+    const run = vi.fn().mockRejectedValue(asIpcError(new VaultLockedError()))
+    const promise = withVaultUnlock('Connecting', run)
+    await vi.waitFor(() => expect(useVaultPrompt.getState().open).toBe(true))
+    useVaultPrompt.getState().finish(false)
+
+    await expect(promise).rejects.toThrow(VAULT_LOCKED)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries once, not forever', async () => {
+    // If it still fails after a successful unlock the cause is something else,
+    // and asking again would be a dialog the user cannot dismiss.
+    const run = vi.fn().mockRejectedValue(asIpcError(new VaultLockedError()))
+    const promise = withVaultUnlock('Connecting', run)
+    await vi.waitFor(() => expect(useVaultPrompt.getState().open).toBe(true))
+    useVaultPrompt.getState().finish(true)
+
+    await expect(promise).rejects.toThrow()
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('never prompts for an unrelated failure', async () => {
+    const run = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'))
+    await expect(withVaultUnlock('Connecting', run)).rejects.toThrow('ECONNREFUSED')
+    expect(useVaultPrompt.getState().open).toBe(false)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('several operations at once', () => {
+  it('asks once and answers all of them', async () => {
+    // Opening three tabs against vault-backed servers should not stack three
+    // identical dialogs.
+    const make = (): ReturnType<typeof vi.fn> =>
+      vi.fn().mockRejectedValueOnce(asIpcError(new VaultLockedError())).mockResolvedValueOnce('ok')
+    const runs = [make(), make(), make()]
+    const all = Promise.all(runs.map((r) => withVaultUnlock('Connecting', r)))
+
+    await vi.waitFor(() => expect(useVaultPrompt.getState().open).toBe(true))
+    useVaultPrompt.getState().finish(true)
+
+    expect(await all).toEqual(['ok', 'ok', 'ok'])
+    for (const r of runs) expect(r).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/workspaceIsolation.test.ts
+++ b/tests/workspaceIsolation.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { TOUR_STEPS } from '../src/renderer/src/components/onboarding/tourSteps'
+
+// What is workspace-scoped and what is not, pinned so the claim and the code
+// cannot drift apart again. The onboarding text said every vault entry belonged
+// to a workspace; it never has.
+
+const types = readFileSync('src/renderer/src/types.ts', 'utf8')
+const vaultShared = readFileSync('src/shared/vault.ts', 'utf8')
+
+const hasWorkspaceId = (src: string, iface: string): boolean => {
+  const start = src.indexOf(`interface ${iface}`)
+  if (start === -1) throw new Error(`no interface ${iface}`)
+  return src.slice(start, src.indexOf('}', start)).includes('workspaceId')
+}
+
+describe('what a workspace actually isolates', () => {
+  it.each(['Server', 'DatabaseConn', 'Tunnel'])('%s is workspace-scoped', (iface) => {
+    expect(hasWorkspaceId(types, iface)).toBe(true)
+  })
+
+  it('a vault entry is not, and the docs must keep saying so', () => {
+    // One vault per installation, shared by every workspace. If this ever gains
+    // a workspaceId the copy asserted below has to change with it.
+    expect(hasWorkspaceId(vaultShared, 'VaultEntry')).toBe(false)
+  })
+})
+
+describe('the walkthrough does not overclaim isolation', () => {
+  it('never says vault entries belong to a workspace', () => {
+    const workspaces = TOUR_STEPS.find((s) => s.id === 'workspaces')!
+    expect(workspaces.body).not.toMatch(/tunnel and vault entry belongs/)
+  })
+
+  it('says explicitly that the vault is shared across workspaces', () => {
+    const text = TOUR_STEPS.map((s) => s.body).join(' ')
+    expect(text).toMatch(/vault is (the exception|shared)|shared across every workspace/i)
+  })
+
+  it('still tells people workspaces can be password-protected', () => {
+    // The real isolation is worth keeping in the tour; only the vault claim was
+    // wrong.
+    expect(TOUR_STEPS.find((s) => s.id === 'workspaces')!.body).toMatch(/password-protect/i)
+  })
+})
+
+describe('SECURITY.md states the boundary', () => {
+  it('says the vault is not workspace-scoped', () => {
+    const doc = readFileSync('SECURITY.md', 'utf8')
+    expect(doc).toMatch(/vault is not workspace-scoped/i)
+  })
+})


### PR DESCRIPTION
Eight commits, rebased onto `main` after v0.3.2. Each is independently reviewable.

## Bugs fixed

**Reconnecting an agent was impossible after revoking a session.** The generated `claude mcp add` command wasn't idempotent — `claude mcp add` refuses a name that already exists, so it worked exactly once and failed every time after, which is precisely when it's needed. And the error told users to "create a new one", which cannot work on its own: the token lives in the client's config, so a new session leaves the dead one in place and returns the identical error.

**The vault entry type picker was decorative.** `entry.kind` was read in exactly one place — the select's own value. A Note asked for a URL, username and password; an API key had nowhere to put the key.

## The vault now holds credentials

It was a password manager sitting beside the SSH client with no connection to it. Every non-vault reference in the codebase was a CSS class name or backup serialisation.

The private key had it worst: stored as a **path**. Not in the keychain, not in the encrypted vault — a filename pointing at plaintext on disk, and the reason an encrypted backup never carried your keys to another machine.

- New **SSH key** kind storing the material
- **Add Server** references a vault entry instead of copying a credential per server — pick a saved one, or type one and have it saved as reusable
- A locked vault **fails loudly** rather than falling back to a stale keychain copy; authenticating with a credential you've since rotated is worse than not connecting
- Redaction follows the credential into the vault

## Touch ID, and asking instead of failing

Unlock with Touch ID, offered right after a password unlock rather than hidden in a toolbar. The offer states the trade honestly: the key is stored on the machine, encrypted by the system keychain.

A vault-backed connection now **prompts in place** and continues on its own, instead of failing with instructions to go and act on elsewhere. Retries once, not in a loop. Concurrent connects join one prompt.

Windows Hello has no Electron API and needs a native module; not pulled in. The provider shape is ready and the UI names whatever the platform actually has rather than offering an inert switch.

## Fleet: services and listening ports

`systemctl` units and `ss`/`netstat` listeners ride the **same single round trip** as the existing sample — no extra connection or poll.

Absent and empty are kept apart throughout: a host without systemd reports `null` and shows "no systemd", not "0 services". *"Nothing is broken"* and *"I can't see whether anything is broken"* are different answers.

## Verification

234 tests (from 84 at the start of this work), three typecheck projects clean, build passes.

Not click-tested in a packaged build — verified in `electron-vite dev`.

## Known scope

`sshTunnel` and `databaseAccess` still gate nothing; the policy groundwork is in this branch but the tools are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)