### PR TITLE
Release 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shellpilot",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Free, open-source SSH client, SFTP browser, SSH tunnel manager, multi-engine database GUI and encrypted secrets vault in one cross-platform desktop app. A MobaXterm, PuTTY and Termius alternative for Windows, macOS and Linux.",
   "keywords": [
     "ssh",


### PR DESCRIPTION
Version bump only. Everything in this release landed in #7.

**Vault** — credentials now live in the vault rather than being copied per server; new SSH key kind stores the material instead of a path. Touch ID unlock, session-scoped by default so nothing extra is written to disk. Idle auto-lock, configurable in Settings → Security. scrypt raised to OWASP's `p=3` with a transparent migration, and a 12-character minimum for new vaults.

**Monitoring** — systemd units and listening ports on the same poll as the existing metrics. Absent and empty are kept apart: a host without systemd says so rather than reporting zero services.

**AI & MCP** — `add_server`, `list_databases`, `query_database`, `list_tunnels`, `set_tunnel`. The `sshTunnel` and `databaseAccess` capabilities finally gate something. Writes and DDL can never resolve better than ASK, whatever the group says.

**Onboarding** — first-run walkthrough, reopenable from Settings.

**Fixes** — reconnecting an agent after revoking a session, the vault entry-type picker that changed nothing, a latent fail-open in biometric unlock, and file-path rules now applying to shell commands rather than only SFTP.

292 tests, three typecheck projects clean, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)