### PR TITLE
Scope vault entries to a workspace

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,14 +48,21 @@ Workspaces isolate **servers, databases and tunnels** — each record carries a
 workspace id and is filtered by it. A password-protected workspace keeps those
 out of sight until it is unlocked.
 
-**The vault is not workspace-scoped.** There is one vault per installation,
-shared by every workspace, and a credential saved in one workspace is visible
-from all of them. Locking a workspace does not hide the vault, because the
-vault does not belong to any workspace.
+**The vault is filtered by workspace, not separated by it.** A vault entry can
+belong to a workspace — new entries belong to the one they were created in —
+and the entry list then shows that workspace's entries plus any marked shared.
+Entries written before this existed have no workspace recorded, so they stay
+shared and can be moved deliberately.
 
-That is the current design, not an oversight in the filtering — but it is easy
-to expect otherwise if you use one workspace per client, so it is stated here
-plainly.
+What that is worth, stated precisely: it stops another client's credentials
+being in front of you, and it stops you saving a credential into the wrong
+place by accident. It is **not** a cryptographic boundary. The vault remains
+one encrypted file under one master password, so anything that can read the
+unlocked vault can read every entry in it regardless of workspace. Locking a
+workspace does not lock the vault.
+
+Per-workspace cryptographic separation would mean a master password per
+workspace, which is a different product; this is a view over one vault.
 
 ### What biometric unlock actually protects
 

--- a/src/renderer/src/components/onboarding/tourSteps.ts
+++ b/src/renderer/src/components/onboarding/tourSteps.ts
@@ -24,7 +24,7 @@ export const TOUR_STEPS: TourStep[] = [
   {
     id: 'workspaces',
     title: 'Workspaces keep clients and environments apart',
-    body: 'Servers, databases and tunnels each belong to a workspace — switch with the picker in the title bar, and password-protect a workspace to keep one client’s infrastructure out of sight. The vault is the exception: it is shared across every workspace, so a credential you save is visible from all of them.',
+    body: 'Servers, databases, tunnels and vault entries each belong to a workspace — switch with the picker in the title bar, and password-protect a workspace to keep one client’s infrastructure out of sight. A vault entry can also be marked shared, when the same credential is genuinely used from several workspaces.',
     action: 'Try the workspace picker at the top left.'
   },
   {
@@ -37,7 +37,7 @@ export const TOUR_STEPS: TourStep[] = [
   {
     id: 'vault',
     title: 'The vault is where credentials live',
-    body: 'Passwords, SSH keys and API keys, encrypted with AES-256-GCM under a master password. One vault for the whole app, not one per workspace — a server in any workspace can reference the same entry, so rotating a credential is one edit instead of a hunt. On a Mac with Touch ID you can unlock with a fingerprint.',
+    body: 'Passwords, SSH keys and API keys, encrypted with AES-256-GCM under a master password. Entries belong to a workspace, or are marked shared when the same credential is used from several. A server references an entry rather than keeping its own copy, so rotating a credential is one edit instead of a hunt. On a Mac with Touch ID you can unlock with a fingerprint.',
     view: 'vault',
     action: 'Create your vault and add a credential.'
   },

--- a/src/renderer/src/components/vault/VaultSidebar.tsx
+++ b/src/renderer/src/components/vault/VaultSidebar.tsx
@@ -1,7 +1,8 @@
 import { KeyRound, Lock, Globe, StickyNote, User, FileKey } from 'lucide-react'
 import { useVault } from '../../store/vault'
 import { clsx } from '../../lib/format'
-import { vaultMatches, type VaultKind } from '../../../../shared/vault'
+import { useApp } from '../../store/app'
+import { vaultMatches, vaultEntriesFor, isSharedVaultEntry, type VaultKind } from '../../../../shared/vault'
 
 const KIND_ICON: Record<VaultKind, React.ReactNode> = {
   login: <User size={13} className="faint" />,
@@ -18,6 +19,7 @@ export function VaultSidebar(): React.JSX.Element {
   const select = useVault((s) => s.select)
   const query = useVault((s) => s.query)
   const setQuery = useVault((s) => s.setQuery)
+  const activeWorkspaceId = useApp((s) => s.activeWorkspaceId)
 
   if (!unlocked) {
     return (
@@ -29,7 +31,12 @@ export function VaultSidebar(): React.JSX.Element {
     )
   }
 
-  const shown = entries.filter((e) => vaultMatches(e, query))
+  // Entries belonging to this workspace, plus the shared ones. Hidden from
+  // view, not cryptographically separated — the vault is still one encrypted
+  // file under one master password, and SECURITY.md says so.
+  const visible = vaultEntriesFor(entries, activeWorkspaceId)
+  const shown = visible.filter((e) => vaultMatches(e, query))
+  const hiddenCount = entries.length - visible.length
 
   return (
     <>
@@ -46,6 +53,13 @@ export function VaultSidebar(): React.JSX.Element {
         <div className="tree-section-label">
           Entries <span className="count">{shown.length}</span>
         </div>
+        {hiddenCount > 0 && (
+          // Saying nothing here would recreate the original confusion in the
+          // opposite direction: entries you saved would simply be missing.
+          <div className="faint" style={{ padding: '2px 12px 6px', fontSize: 11 }}>
+            {hiddenCount} more in other workspaces
+          </div>
+        )}
         {shown.map((e) => (
           <div
             key={e.id}
@@ -54,6 +68,11 @@ export function VaultSidebar(): React.JSX.Element {
             title={e.url || e.username || e.name}
           >
             {KIND_ICON[e.kind]}
+            {isSharedVaultEntry(e) && (
+              <span className="faint" style={{ fontSize: 10 }} title="Visible in every workspace">
+                shared
+              </span>
+            )}
             <span className="label">{e.name}</span>
           </div>
         ))}

--- a/src/renderer/src/components/vault/VaultView.tsx
+++ b/src/renderer/src/components/vault/VaultView.tsx
@@ -3,6 +3,7 @@ import { Copy, Eye, EyeOff, Fingerprint, KeyRound, Lock, Plus, ShieldCheck, Tras
 import { useVault, newField } from '../../store/vault'
 import { toast } from '../../store/toast'
 import { clsx } from '../../lib/format'
+import { useApp } from '../../store/app'
 import { bridgeOn } from '../../lib/bridge'
 import {
   VAULT_KIND_LABEL,
@@ -358,6 +359,7 @@ function EntryEditor({ entry }: { entry: VaultEntry }): React.JSX.Element {
   const setField = (id: string, patch: Partial<(typeof entry.fields)[number]>): void =>
     set({ fields: entry.fields.map((f) => (f.id === id ? { ...f, ...patch } : f)) })
 
+  const workspaces = useApp((s) => s.workspaces)
   const shown = VAULT_KIND_FIELDS[entry.kind] ?? VAULT_KIND_FIELDS.login
 
   // A value that belongs to a field this kind does not show is still stored and
@@ -428,6 +430,23 @@ function EntryEditor({ entry }: { entry: VaultEntry }): React.JSX.Element {
           onReveal={() => toggle('__pw')}
         />
       )}
+      <div className="row" style={{ gap: 6 }}>
+        <span className="vault-label">Workspace</span>
+        <select
+          className="input"
+          style={{ flex: 1 }}
+          value={entry.workspaceId ?? ''}
+          onChange={(e) => set({ workspaceId: e.target.value || undefined })}
+        >
+          <option value="">Shared — visible in every workspace</option>
+          {workspaces.map((w) => (
+            <option key={w.id} value={w.id}>
+              {w.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
       <Row
         label="Tags"
         value={entry.tags.join(', ')}

--- a/src/renderer/src/store/vault.ts
+++ b/src/renderer/src/store/vault.ts
@@ -1,15 +1,20 @@
 import { create } from 'zustand'
+import { useApp } from './app'
 import type { VaultEntry, VaultField, VaultKind } from '../../../shared/vault'
 
 let seq = 0
 const uid = (p: string): string => `${p}-${Date.now().toString(36)}-${seq++}`
 
-export function newEntry(kind: VaultKind = 'login'): VaultEntry {
+// A new entry belongs to the workspace it was made in. That is the behaviour
+// people expect from a workspace, and the alternative — defaulting to shared —
+// silently reproduces the problem this exists to fix.
+export function newEntry(kind: VaultKind = 'login', workspaceId?: string): VaultEntry {
   const now = new Date().toISOString()
   return {
     id: uid('v'),
     name: 'New entry',
     kind,
+    workspaceId,
     url: '',
     username: '',
     password: '',
@@ -187,14 +192,14 @@ export const useVault = create<VaultState>((set, get) => ({
   setQuery: (q) => set({ query: q }),
 
   addEntry: async (kind = 'login') => {
-    const e = newEntry(kind)
+    const e = newEntry(kind, useApp.getState().activeWorkspaceId)
     const entries = [...get().entries, e]
     set({ entries, selectedId: e.id })
     await persist(entries, set)
   },
 
   createEntry: async (kind, patch) => {
-    const e = { ...newEntry(kind), ...patch }
+    const e = { ...newEntry(kind, useApp.getState().activeWorkspaceId), ...patch }
     const entries = [...get().entries, e]
     set({ entries })
     await persist(entries, set)

--- a/src/shared/vault.ts
+++ b/src/shared/vault.ts
@@ -13,6 +13,19 @@ export interface VaultEntry {
   id: string
   name: string
   kind: VaultKind
+  // Which workspace this entry belongs to, or absent for one that is visible
+  // everywhere.
+  //
+  // Absent is the honest default for entries that predate this field: the
+  // vault was a single global store, so there is no record of which workspace
+  // any of them was created in, and guessing would either hide a credential
+  // someone relies on or claim knowledge we do not have. They stay shared and
+  // can be moved deliberately.
+  //
+  // Shared is also a real, wanted state — a credential used from several
+  // workspaces should exist once, which is the whole reason a server
+  // references a vault entry rather than copying it.
+  workspaceId?: string
   url: string
   username: string
   // Doubles as the key passphrase on an `sshkey` entry. One secret slot, whose
@@ -58,6 +71,21 @@ export const VAULT_KIND_LABEL: Record<VaultKind, string> = {
   key: 'API key',
   sshkey: 'SSH key',
   note: 'Note'
+}
+
+// Entries visible from a given workspace: the ones that belong to it, plus the
+// shared ones. Filtering happens in the renderer rather than in the vault
+// service because the vault file is one encrypted blob — splitting it per
+// workspace would mean a master password per workspace, which is a different
+// product. This hides entries from view; it is not a cryptographic boundary,
+// and SECURITY.md says so.
+export function vaultEntriesFor(entries: VaultEntry[], workspaceId: string | null): VaultEntry[] {
+  if (!workspaceId) return entries
+  return entries.filter((e) => !e.workspaceId || e.workspaceId === workspaceId)
+}
+
+export function isSharedVaultEntry(e: VaultEntry): boolean {
+  return !e.workspaceId
 }
 
 // Matches an entry against a search query across every stored field, so the

--- a/tests/vaultWorkspaceScoping.test.ts
+++ b/tests/vaultWorkspaceScoping.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { vaultEntriesFor, isSharedVaultEntry, type VaultEntry } from '../src/shared/vault'
+
+// The vault was a single global store: creating a new workspace showed the
+// entries from the old one. Entries can now belong to a workspace, with
+// "shared" as a real state rather than an accident.
+
+const entry = (id: string, workspaceId?: string): VaultEntry => ({
+  id,
+  name: id,
+  kind: 'login',
+  workspaceId,
+  url: '',
+  username: '',
+  password: '',
+  notes: '',
+  tags: [],
+  fields: [],
+  createdAt: '',
+  updatedAt: ''
+})
+
+const all = [entry('prod-db', 'ws-a'), entry('client-vpn', 'ws-b'), entry('company-wifi')]
+
+describe('what a workspace shows', () => {
+  it('shows its own entries and the shared ones, not another workspace’s', () => {
+    expect(vaultEntriesFor(all, 'ws-a').map((e) => e.id)).toEqual(['prod-db', 'company-wifi'])
+    expect(vaultEntriesFor(all, 'ws-b').map((e) => e.id)).toEqual(['client-vpn', 'company-wifi'])
+  })
+
+  it('treats an entry with no workspace as shared', () => {
+    // Entries written before the field existed have no record of where they
+    // came from. Guessing would either hide a credential someone relies on or
+    // claim knowledge we do not have.
+    expect(isSharedVaultEntry(entry('legacy'))).toBe(true)
+    expect(vaultEntriesFor([entry('legacy')], 'ws-a')).toHaveLength(1)
+  })
+
+  it('is not a way to lose an entry — every one is visible from somewhere', () => {
+    const reachable = new Set(
+      ['ws-a', 'ws-b'].flatMap((ws) => vaultEntriesFor(all, ws).map((e) => e.id))
+    )
+    expect(reachable).toEqual(new Set(all.map((e) => e.id)))
+  })
+
+  it('shows everything when no workspace is active', () => {
+    expect(vaultEntriesFor(all, null)).toHaveLength(3)
+  })
+
+  it('hides nothing from a workspace whose entries are all shared', () => {
+    const shared = [entry('a'), entry('b')]
+    expect(vaultEntriesFor(shared, 'ws-a')).toHaveLength(2)
+  })
+
+  it('reports how many are hidden, so they do not just vanish', () => {
+    // Saying nothing would recreate the original confusion in the opposite
+    // direction: entries you saved would simply be missing.
+    const visible = vaultEntriesFor(all, 'ws-a')
+    expect(all.length - visible.length).toBe(1)
+  })
+})
+
+describe('what this is not', () => {
+  it('does not separate entries cryptographically', () => {
+    // One encrypted file, one master password. Filtering is a view, and the
+    // shape of the data says so: every entry is in the same array.
+    const everything = vaultEntriesFor(all, null)
+    expect(everything).toHaveLength(all.length)
+    expect(everything.some((e) => e.workspaceId === 'ws-b')).toBe(true)
+  })
+})

--- a/tests/workspaceIsolation.test.ts
+++ b/tests/workspaceIsolation.test.ts
@@ -20,22 +20,19 @@ describe('what a workspace actually isolates', () => {
     expect(hasWorkspaceId(types, iface)).toBe(true)
   })
 
-  it('a vault entry is not, and the docs must keep saying so', () => {
-    // One vault per installation, shared by every workspace. If this ever gains
-    // a workspaceId the copy asserted below has to change with it.
-    expect(hasWorkspaceId(vaultShared, 'VaultEntry')).toBe(false)
+  it('a vault entry can belong to one, optionally', () => {
+    // Optional, because "shared" is a real state: one credential used from
+    // several workspaces should exist once.
+    expect(vaultShared).toMatch(/workspaceId\?: string/)
   })
 })
 
 describe('the walkthrough does not overclaim isolation', () => {
-  it('never says vault entries belong to a workspace', () => {
-    const workspaces = TOUR_STEPS.find((s) => s.id === 'workspaces')!
-    expect(workspaces.body).not.toMatch(/tunnel and vault entry belongs/)
-  })
-
-  it('says explicitly that the vault is shared across workspaces', () => {
+  it('explains that an entry can be shared rather than implying total isolation', () => {
+    // The vault is filtered by workspace, not cryptographically separated, and
+    // the tour must not imply otherwise.
     const text = TOUR_STEPS.map((s) => s.body).join(' ')
-    expect(text).toMatch(/vault is (the exception|shared)|shared across every workspace/i)
+    expect(text).toMatch(/marked shared/i)
   })
 
   it('still tells people workspaces can be password-protected', () => {
@@ -46,8 +43,9 @@ describe('the walkthrough does not overclaim isolation', () => {
 })
 
 describe('SECURITY.md states the boundary', () => {
-  it('says the vault is not workspace-scoped', () => {
+  it('says filtering is not a cryptographic boundary', () => {
     const doc = readFileSync('SECURITY.md', 'utf8')
-    expect(doc).toMatch(/vault is not workspace-scoped/i)
+    expect(doc).toMatch(/filtered by workspace, not separated by it/i)
+    expect(doc).toMatch(/not\*{0,2} a cryptographic boundary/i)
   })
 })


### PR DESCRIPTION
Reported from use: creating a new workspace showed the entries from the old one. The vault was a single global store — servers, databases and tunnels each carried a `workspaceId`; vault entries did not.

## Change

A vault entry can now belong to a workspace, and a new entry belongs to the one it was created in. The entry list shows that workspace's entries plus any marked **shared**.

**Shared is a deliberate state, not just a legacy one.** One credential used from several workspaces should exist once — that's the whole reason a server references a vault entry instead of copying it.

**Existing entries stay shared.** They have no record of which workspace they came from, so guessing would either hide a credential someone relies on or claim knowledge we don't have. They can be moved by hand from the entry editor.

**The sidebar says how many entries are in other workspaces.** Saying nothing would recreate the original confusion in the opposite direction — entries you saved would simply be missing.

## What this is not

A cryptographic boundary, and SECURITY.md now says so precisely. The vault remains one encrypted file under one master password: anything that can read it unlocked can read every entry regardless of workspace, and locking a workspace does not lock the vault.

Per-workspace separation would mean a master password per workspace, which is a different product. This stops another client's credentials being in front of you, and stops you saving one into the wrong place. It does not defend one workspace against another.

## Also

The onboarding copy that started this — *"every server, database, tunnel and vault entry belongs to a workspace"* — is now true rather than aspirational. Tests read the interfaces and assert which types carry a `workspaceId`, so the claim and the code can't drift apart again.

306 tests, typecheck clean, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)