### PR TITLE
Release 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shellpilot",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Free, open-source SSH client, SFTP browser, SSH tunnel manager, multi-engine database GUI and encrypted secrets vault in one cross-platform desktop app. A MobaXterm, PuTTY and Termius alternative for Windows, macOS and Linux.",
   "keywords": [
     "ssh",


### PR DESCRIPTION
Version bump only. The change landed in #9.

Vault entries now belong to a workspace, so creating a new workspace no longer shows the previous one's credentials. Entries that predate the field have no record of where they came from, so they stay shared and can be moved from the entry editor.

Filtering, not cryptographic separation — SECURITY.md states the boundary.

306 tests, typecheck clean, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)