### PR TITLE
Enable the hardened runtime on macOS builds

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,22 @@ Knowing the design may help you assess a finding.
 | AI/MCP audit log | `shellpilot-ai-audit.jsonl` | Plaintext, append-only. Free-text fields are passed through the same secret-redaction as command output before being written, so it should never contain a credential. |
 | AI/MCP access-group policy | `shellpilot-ai-policy.json` | Plaintext. Contains no credentials — capability rules and file-path patterns only. |
 
+### Process hardening
+
+macOS builds run with the **hardened runtime**, which blocks
+`DYLD_INSERT_LIBRARIES` injection and debugger attach. This matters more than
+any of the vault's own protections: without it, a process running as the same
+user can inject into ShellPilot and read an unlocked vault key out of memory,
+and no amount of encryption at rest or biometric gating prevents that.
+
+The hardened runtime does not require an Apple Developer certificate — it works
+with the ad-hoc signature these builds already carry.
+
+Library validation is disabled by entitlement, because `asarUnpack` keeps the
+ssh2 and cpu-features native binaries outside the archive deliberately. That
+gives back one of the three protections the hardened runtime provides and keeps
+the two that defend an unlocked vault.
+
 ### Workspaces and the vault
 
 Workspaces isolate **servers, databases and tunnels** — each record carries a

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -3,9 +3,9 @@
 <plist version="1.0">
 <dict>
   <!--
-    Unused until a Developer ID certificate exists; electron-builder.yml
-    references it only when hardenedRuntime is turned on. Written now so
-    enabling signing is a configuration change rather than a research task.
+    In use. The hardened runtime is enabled with ad-hoc signing — it does not
+    require a Developer ID, and it blocks DYLD injection and debugger attach
+    whether or not the build is notarized.
 
     Library validation must be disabled: asarUnpack deliberately keeps the ssh2
     and cpu-features .node binaries outside the archive, and hardened runtime

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -83,19 +83,26 @@ mac:
   # written and carries the library-validation exception the unpacked ssh2 and
   # cpu-features binaries need.
   identity: '-'
-  # Hardened runtime turns on library validation, which refuses to load the
-  # ssh2/cpu-features .node binaries that asarUnpack deliberately keeps outside
-  # the archive, so it is off here.
+  # On, despite there being no Developer ID. The hardened runtime blocks
+  # DYLD_INSERT_LIBRARIES injection and debugger attach regardless of
+  # notarization, and without it a process running as the same user can inject
+  # into ShellPilot and read an unlocked vault key straight out of memory —
+  # which defeats every protection the vault has, biometrics included.
   #
-  # Note this is a real cost, not a free choice: DYLD_INSERT_LIBRARIES injection
-  # and debugger attach are blocked by the hardened runtime regardless of
-  # notarization, so leaving it off means a process running as the same user can
-  # inject into ShellPilot and read an unlocked vault key straight out of memory.
-  # Turning it on needs com.apple.security.cs.disable-library-validation for the
-  # .node binaries — which gives back the library-validation half but keeps the
-  # DYLD and debugger hardening. Worth doing; it needs an entitlements plist and
-  # a build to verify the native modules still load.
-  hardenedRuntime: false
+  # The entitlements plist disables library validation, because asarUnpack
+  # deliberately keeps the ssh2 and cpu-features .node binaries outside the
+  # archive. That gives back one of the three protections and keeps the two
+  # that matter here.
+  #
+  # Verified before enabling, on an ad-hoc signed arm64 build: signs cleanly
+  # (adhoc,runtime, 132 sealed files, codesign --verify --strict passes), the
+  # app launches with its renderer and helpers, and an ssh2 connection to a
+  # real host completes. The native crypto binding does not load — but it does
+  # not load without the hardened runtime either, and ssh2 falls back to pure
+  # JS, so SSH is unaffected.
+  hardenedRuntime: true
+  entitlements: build/entitlements.mac.plist
+  entitlementsInherit: build/entitlements.mac.plist
   target:
     - target: dmg
       arch: [x64, arm64]

--- a/tests/releaseWorkflow.test.ts
+++ b/tests/releaseWorkflow.test.ts
@@ -127,3 +127,25 @@ describe('inline shell in the release job does not keep growing', () => {
     expect(named.sort()).toEqual(Object.keys(CEILING).sort())
   })
 })
+
+describe('macOS build hardening', () => {
+  const builder = load(readFileSync('electron-builder.yml', 'utf8')) as {
+    mac?: { hardenedRuntime?: boolean; entitlements?: string; identity?: string }
+  }
+
+  it('enables the hardened runtime', () => {
+    // Without it a same-user process can inject into ShellPilot and read an
+    // unlocked vault key from memory, which defeats every protection the vault
+    // has. It needs no Developer ID — ad-hoc signing carries it fine.
+    expect(builder.mac?.hardenedRuntime).toBe(true)
+  })
+
+  it('ships the entitlements the hardened runtime needs', () => {
+    // asarUnpack keeps ssh2/cpu-features .node binaries outside the archive on
+    // purpose; without disable-library-validation they will not load.
+    expect(builder.mac?.entitlements).toBe('build/entitlements.mac.plist')
+    const plist = readFileSync('build/entitlements.mac.plist', 'utf8')
+    expect(plist).toContain('com.apple.security.cs.disable-library-validation')
+    expect(plist).toContain('com.apple.security.cs.allow-jit')
+  })
+})


### PR DESCRIPTION
Verified against your host at `13.251.230.58` rather than by inspection.

## Why

Without the hardened runtime, a process running as the same user can inject via `DYLD_INSERT_LIBRARIES` or attach a debugger and read an unlocked vault key straight out of memory. That defeats **every** protection the vault has — encryption at rest, the biometric gate, the session-scoped key — so it matters more than any of them.

**It needs no Apple Developer certificate.** The hardened runtime works with the ad-hoc signature these builds already carry, and blocks injection and debugger attach whether or not the build is notarized. My earlier comment in `electron-builder.yml` said it "only buys anything alongside notarization" — that was wrong.

## What was verified before enabling

| Check | Result |
|---|---|
| Signature | `flags=0x10002(adhoc,runtime)`, sealed resources, `codesign --verify --strict` passes |
| Entitlements embedded | `disable-library-validation`, `allow-jit`, `allow-unsigned-executable-memory` |
| Packaged app launches | main + renderer + helper processes alive |
| Full dmg pipeline | builds and signs |
| **Real SSH connection** | `ssh2` connected and ran a command on a remote host |

The native crypto binding does not load under the hardened runtime — but **it does not load without it either**, so that is pre-existing. `ssh2` falls back to pure JS and SSH is unaffected. That is exactly why the library-validation concern which kept this off turned out to be smaller than it looked.

## Note

Library validation is disabled by entitlement, because `asarUnpack` keeps the ssh2 and cpu-features native binaries outside the archive deliberately. That gives back one of the three protections the hardened runtime provides and keeps the two that defend an unlocked vault.

Tests assert the config stays this way, so it cannot be silently turned off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)