### PR TITLE
Release 0.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shellpilot",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Free, open-source SSH client, SFTP browser, SSH tunnel manager, multi-engine database GUI and encrypted secrets vault in one cross-platform desktop app. A MobaXterm, PuTTY and Termius alternative for Windows, macOS and Linux.",
   "keywords": [
     "ssh",


### PR DESCRIPTION
Version bump. Ships the hardened runtime (#11) together with the Monitor tab and update-check work already on main.

**Note on v0.4.2:** that tag exists on the remote but never triggered a release workflow and has no release object — a dangling tag. 0.4.3 supersedes it and carries everything 0.4.2 would have.

311 tests, typecheck clean, build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)