### PR TITLE
Make a pending AI approval visible, and recognise hosts OpenSSH already trusts

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,6 +42,34 @@ Knowing the design may help you assess a finding.
 | AI/MCP audit log | `shellpilot-ai-audit.jsonl` | Plaintext, append-only. Free-text fields are passed through the same secret-redaction as command output before being written, so it should never contain a credential. |
 | AI/MCP access-group policy | `shellpilot-ai-policy.json` | Plaintext. Contains no credentials — capability rules and file-path patterns only. |
 
+### SSH host keys
+
+ShellPilot does trust-on-first-use host key checking against its own
+`shellpilot-known-hosts.json`. Without it, ssh2 accepts any key presented, so
+anything on the path to a server could capture the session and the credentials
+sent over it.
+
+It also **reads** `~/.ssh/known_hosts` (and `known_hosts2`), but never inherits
+trust from it. Adopting that file wholesale would silently take on every trust
+decision it has accumulated, including whatever `StrictHostKeyChecking=accept-new`
+waved through unattended. So an entry there only changes what the prompt says:
+a host whose exact key OpenSSH already has is presented as recognised, and the
+dialog defaults to Trust instead of Cancel. A human still confirms it once.
+
+Two cases there are not merely informational:
+
+- **`@revoked`** matching the presented key refuses the connection outright. It
+  is a negative signal, so acting on it without asking only ever restricts.
+- **A host present under a different key** is called out explicitly in the
+  prompt, since that is either a rebuilt server or an interception.
+
+`@cert-authority` lines are ignored. They authorise certificates rather than
+naming a host key, and ShellPilot cannot validate a certificate chain — so they
+are treated as no evidence rather than as trust.
+
+Once a host is trusted, a *changed* key is always refused outright and never
+re-prompted: the user has to forget the saved key in Settings → Security first.
+
 ### Process hardening
 
 macOS builds run with the **hardened runtime**, which blocks

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -69,7 +69,7 @@ import {
   listServerMeta,
   setServerAliases
 } from './services/policyStore'
-import type { AccessGroup, McpGlobalConfig, PolicyAssignment } from '../shared/mcp'
+import type { AccessGroup, ApprovalRequest, McpGlobalConfig, PolicyAssignment } from '../shared/mcp'
 import {
   getMcpConfig,
   setMcpConfig,
@@ -427,6 +427,34 @@ ipcMain.handle('sshconfig:read', () => {
   }
 })
 
+// An approval blocks an AI agent until the user answers it, and the dialog it
+// renders lives inside the window. If ShellPilot is not in front, nothing tells
+// the user anything is waiting — the agent simply appears to hang for the
+// whole timeout, which is exactly how it was reported.
+function notifyApprovalPending(request: ApprovalRequest): void {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    // Bounces the dock icon on macOS, flashes the taskbar on Windows. Left as
+    // 'informational' rather than 'critical': the request expires on its own,
+    // so it does not warrant a bouncing icon that will not stop.
+    app.dock?.bounce('informational')
+    mainWindow.flashFrame(true)
+  }
+  if (!Notification.isSupported()) return
+  const n = new Notification({
+    title: `${request.agentName} needs approval`,
+    body: `${request.action}\non ${request.serverName}`,
+    icon: appIcon()
+  })
+  n.on('click', () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      if (mainWindow.isMinimized()) mainWindow.restore()
+      mainWindow.show()
+      mainWindow.focus()
+    }
+  })
+  n.show()
+}
+
 // ---- Notifications ----
 // Native OS notifications: they render outside the window, so they can never
 // cover the terminal, and the OS handles stacking and dismissal.
@@ -598,6 +626,9 @@ ipcMain.handle('aiMcp:respondApproval', (_e, id: string, decision: 'approved' | 
 )
 onApprovalEvent((e) => {
   if (mainWindow && !mainWindow.isDestroyed()) mainWindow.webContents.send('ai:approval-event', e)
+  if (e.type === 'created') notifyApprovalPending(e.request)
+  // Stop the taskbar flashing once the thing it was flashing about is answered.
+  if (e.type === 'resolved' && mainWindow && !mainWindow.isDestroyed()) mainWindow.flashFrame(false)
 })
 
 // ---- AI & MCP: agent-initiated server creation (the add_server tool) ----

--- a/src/main/services/knownhosts.ts
+++ b/src/main/services/knownhosts.ts
@@ -2,6 +2,7 @@ import { app, dialog } from 'electron'
 import { join } from 'node:path'
 import { existsSync, readFileSync, writeFileSync, renameSync } from 'node:fs'
 import { createHash } from 'node:crypto'
+import { readOpenSshKnownHosts, lookupInKnownHosts, canonicalHostname } from './opensshKnownHosts'
 
 // Trust-on-first-use host key checking. Without this, ssh2 accepts any host
 // key presented, so a machine-in-the-middle on the path to a server can
@@ -80,14 +81,45 @@ export function verifyHostKey(host: string, port: number, key: Buffer): Promise<
   const inFlight = pending.get(id)
   if (inFlight) return inFlight
 
+  // What OpenSSH already thinks of this host. This never grants trust by
+  // itself — see opensshKnownHosts.ts for why — it only changes what the
+  // prompt says, so a host you use daily in your terminal is not announced as
+  // a total stranger. Revocation is the exception: it is a negative signal.
+  const openssh = lookupInKnownHosts(readOpenSshKnownHosts(), host, port, fingerprint, fp)
+
+  if (openssh.revoked) {
+    return dialog
+      .showMessageBox({
+        type: 'error',
+        title: 'Host key revoked',
+        message: `The host key for ${id} is marked @revoked in your ~/.ssh/known_hosts.`,
+        detail: `Fingerprint: ${fp}\n\nThe connection has been refused. Remove the @revoked line if this was a mistake.`,
+        buttons: ['OK'],
+        defaultId: 0
+      })
+      .then(() => false)
+  }
+
+  const recognised = openssh.trusted
   const prompt = dialog
     .showMessageBox({
-      type: 'warning',
-      title: 'Unknown host',
-      message: `The authenticity of ${id} cannot be established.`,
-      detail: `Fingerprint: ${fp}\n\nTrust this host and remember it for future connections?`,
+      type: recognised ? 'question' : 'warning',
+      title: recognised ? 'Confirm host' : 'Unknown host',
+      message: recognised
+        ? `${id} is already trusted in your ~/.ssh/known_hosts.`
+        : `The authenticity of ${id} cannot be established.`,
+      detail: recognised
+        ? `Fingerprint: ${fp}\n\nThis is the same key OpenSSH has for ${canonicalHostname(host, port)}. ` +
+          'ShellPilot keeps its own list of trusted hosts, so it has to be added here once too.'
+        : openssh.knownUnderAnotherKey
+          ? `Fingerprint: ${fp}\n\nWarning: ~/.ssh/known_hosts has an entry for this host under a different key. ` +
+            'That can mean the server was rebuilt, or that this connection is being intercepted. ' +
+            'Check the fingerprint before trusting it.'
+          : `Fingerprint: ${fp}\n\nTrust this host and remember it for future connections?`,
       buttons: ['Trust and connect', 'Cancel'],
-      defaultId: 1,
+      // Pre-selecting Trust is only defensible when we have independent
+      // evidence for this exact key; anything else keeps Cancel as the default.
+      defaultId: recognised ? 0 : 1,
       cancelId: 1
     })
     .then((r) => {

--- a/src/main/services/mcpServer.ts
+++ b/src/main/services/mcpServer.ts
@@ -88,6 +88,38 @@ function bearerFrom(headers: RequestInfoLike['headers']): string | null {
 
 interface ExtraLike {
   requestInfo?: RequestInfoLike
+  // Present when the client asked for out-of-band progress on this call. The
+  // spec says the receiver is not obligated to send any, so everything that
+  // reads these has to cope with them being absent.
+  _meta?: { progressToken?: string | number }
+  sendNotification?: (n: {
+    method: 'notifications/progress'
+    params: { progressToken: string | number; progress: number; total?: number; message?: string }
+  }) => Promise<void>
+}
+
+// An ASK-tier call blocks until a human answers it in ShellPilot, which can be
+// the full approval timeout. Without this the agent sees no output at all for
+// that whole window and reports the tool as hung — which is exactly what got
+// reported. A progress notification is the only in-band way to say "still
+// alive, waiting on a human". Clients that sent no progressToken get nothing,
+// and a client that ignores progress is no worse off than before.
+async function noteAwaitingApproval(extra: ExtraLike, action: string, serverName: string): Promise<void> {
+  const token = extra._meta?.progressToken
+  if (token === undefined || !extra.sendNotification) return
+  try {
+    await extra.sendNotification({
+      method: 'notifications/progress',
+      params: {
+        progressToken: token,
+        progress: 0,
+        message: `Waiting for a human to approve "${action}" on ${serverName} in ShellPilot. This is not stuck — approve or deny it in the ShellPilot window.`
+      }
+    })
+  } catch {
+    // A failed progress notification must never take down the tool call that
+    // it was only annotating.
+  }
 }
 
 function authenticateExtra(extra: ExtraLike): { session: McpAgentSession } | { error: AuthFailureReason } {
@@ -237,7 +269,8 @@ interface AuditContext {
 async function gate(
   ctx: AuditContext,
   check: { decision: 'allow' | 'ask' | 'deny'; reason: string },
-  risk: 'low' | 'medium' | 'high'
+  risk: 'low' | 'medium' | 'high',
+  extra?: ExtraLike
 ): Promise<{ ok: true } | { ok: false; result: CallToolResult }> {
   if (check.decision === 'deny') {
     recordAudit({
@@ -260,6 +293,7 @@ async function gate(
     if (!ctx.serverId || !ctx.serverName || !ctx.capability || !ctx.workspaceId || !ctx.workspaceName) {
       return { ok: false, result: errorText('Denied: this action requires approval but has no server context.') }
     }
+    if (extra) await noteAwaitingApproval(extra, ctx.action, ctx.serverName)
     const decision = await requestApproval({
       sessionId: ctx.session.id,
       agentName: ctx.session.agentName,
@@ -288,7 +322,7 @@ async function gate(
         ok: false,
         result: errorText(
           decision === 'timeout'
-            ? 'Denied: approval request timed out waiting for the user.'
+            ? `Denied: nobody answered the approval request for this action within the timeout. It was waiting in the ShellPilot window. Ask the user to approve it there, or to raise the capability for ${ctx.serverName} from Ask to Allow in AI & MCP > Access, then retry.`
             : 'Denied: the user rejected this action.'
         )
       }
@@ -540,7 +574,7 @@ function buildServer(): McpServer {
         capability: 'terminal'
       }
       const risk = check.decision === 'deny' ? 'high' : /sudo\b/.test(command) ? 'high' : 'medium'
-      const gated = await gate(ctx, check, risk)
+      const gated = await gate(ctx, check, risk, extra)
       if (!gated.ok) return gated.result
 
       const secrets = knownSecretValuesForServer(s.id)
@@ -600,7 +634,7 @@ function buildServer(): McpServer {
         action: `read ${path}`,
         capability: 'readFiles'
       }
-      const gated = await gate(ctx, check, 'low')
+      const gated = await gate(ctx, check, 'low', extra)
       if (!gated.ok) return gated.result
 
       const secrets = knownSecretValuesForServer(s.id)
@@ -650,7 +684,7 @@ function buildServer(): McpServer {
         action: `write ${path} (${content.length} bytes)`,
         capability: 'writeFiles'
       }
-      const gated = await gate(ctx, check, 'medium')
+      const gated = await gate(ctx, check, 'medium', extra)
       if (!gated.ok) return gated.result
 
       const cfg = resolveChainSecrets(serverToSshConfig(s))
@@ -697,7 +731,7 @@ function buildServer(): McpServer {
         action: `list ${path}`,
         capability: 'readFiles'
       }
-      const gated = await gate(ctx, check, 'low')
+      const gated = await gate(ctx, check, 'low', extra)
       if (!gated.ok) return gated.result
 
       const cfg = resolveChainSecrets(serverToSshConfig(s))
@@ -743,7 +777,7 @@ function buildServer(): McpServer {
         action: 'get_server_metrics',
         capability: 'serverMetrics'
       }
-      const gated = await gate(ctx, check, 'low')
+      const gated = await gate(ctx, check, 'low', extra)
       if (!gated.ok) return gated.result
 
       const cfg = resolveChainSecrets(serverToSshConfig(s))
@@ -846,7 +880,7 @@ function buildServer(): McpServer {
         capability: 'databaseAccess'
       }
 
-      const gated = await gate(ctx, check, classifyStatement(statement) === 'read' ? 'low' : 'high')
+      const gated = await gate(ctx, check, classifyStatement(statement) === 'read' ? 'low' : 'high', extra)
       if (!gated.ok) return gated.result
 
       const approval = check.decision === 'ask' ? 'approved' : 'not-required'
@@ -951,7 +985,7 @@ function buildServer(): McpServer {
         capability: 'sshTunnel'
       }
 
-      const gated = await gate(ctx, check, running ? 'high' : 'low')
+      const gated = await gate(ctx, check, running ? 'high' : 'low', extra)
       if (!gated.ok) return gated.result
       const approval = check.decision === 'ask' ? 'approved' : 'not-required'
 
@@ -1066,7 +1100,7 @@ function buildServer(): McpServer {
       }
 
       const check = effectiveWorkspaceCapability(session, workspace.id, 'manageServers')
-      const gated = await gate(ctx, check, 'high')
+      const gated = await gate(ctx, check, 'high', extra)
       if (!gated.ok) return gated.result
 
       const result = await createServerForAgent({

--- a/src/main/services/opensshKnownHosts.ts
+++ b/src/main/services/opensshKnownHosts.ts
@@ -1,0 +1,159 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { existsSync, readFileSync } from 'node:fs'
+import { createHmac } from 'node:crypto'
+
+// Reads OpenSSH's own ~/.ssh/known_hosts.
+//
+// ShellPilot keeps a separate trust store, which is deliberate: importing
+// someone's accumulated known_hosts wholesale would silently adopt years of
+// trust decisions, including everything an `accept-new` ever waved through.
+// But not looking at it at all produces the opposite problem, and that is the
+// one users actually hit — a host you connect to from your terminal every day
+// is announced as an unknown host the first time ShellPilot sees it.
+//
+// So this module only ever *informs* the prompt. It never grants trust on its
+// own. The one exception is @revoked, which is a negative signal and is
+// therefore safe to act on without asking.
+
+export type Marker = 'cert-authority' | 'revoked' | null
+
+export interface OpenSshHostEntry {
+  marker: Marker
+  // Comma-separated host patterns, verbatim. Empty when the line is hashed.
+  patterns: string[]
+  // OpenSSH's HashKnownHosts form: |1|<base64 salt>|<base64 HMAC-SHA1>.
+  hashed: { salt: string; hash: string } | null
+  keyType: string
+  // The raw key blob, base64-decoded. Fingerprinting this gives exactly the
+  // same bytes ssh2 hands us for the key the server presented, so entries are
+  // compared by key identity rather than by key type.
+  key: Buffer
+}
+
+export function parseKnownHosts(text: string): OpenSshHostEntry[] {
+  const out: OpenSshHostEntry[] = []
+  for (const raw of text.split('\n')) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+
+    let rest = line
+    let marker: Marker = null
+    if (rest.startsWith('@')) {
+      const [tag, ...tail] = rest.split(/\s+/)
+      if (tag === '@cert-authority') marker = 'cert-authority'
+      else if (tag === '@revoked') marker = 'revoked'
+      else continue // An unknown marker means an unknown format; do not guess.
+      rest = tail.join(' ')
+    }
+
+    const parts = rest.split(/\s+/)
+    if (parts.length < 3) continue
+    const [hosts, keyType, keyB64] = parts
+
+    let key: Buffer
+    try {
+      key = Buffer.from(keyB64, 'base64')
+      if (key.length === 0) continue
+    } catch {
+      continue
+    }
+
+    if (hosts.startsWith('|1|')) {
+      const [, , salt, hash] = hosts.split('|')
+      if (!salt || !hash) continue
+      out.push({ marker, patterns: [], hashed: { salt, hash }, keyType, key })
+    } else {
+      out.push({ marker, patterns: hosts.split(','), hashed: null, keyType, key })
+    }
+  }
+  return out
+}
+
+// OpenSSH writes a non-default port as "[host]:port" and a default one as the
+// bare host, and hashes that same canonical string. Getting this wrong is how
+// a trusted host on port 22000 reads as unknown.
+export function canonicalHostname(host: string, port: number): string {
+  const p = port || 22
+  return p === 22 ? host : `[${host}]:${p}`
+}
+
+function globToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`^${escaped.replace(/\*/g, '.*').replace(/\?/g, '.')}$`)
+}
+
+function patternsMatch(patterns: string[], name: string): boolean {
+  let matched = false
+  for (const pattern of patterns) {
+    if (pattern.startsWith('!')) {
+      // A negation anywhere in the list overrides every positive match.
+      if (globToRegExp(pattern.slice(1)).test(name)) return false
+    } else if (globToRegExp(pattern).test(name)) {
+      matched = true
+    }
+  }
+  return matched
+}
+
+export function entryMatchesHost(entry: OpenSshHostEntry, name: string): boolean {
+  if (entry.hashed) {
+    const mac = createHmac('sha1', Buffer.from(entry.hashed.salt, 'base64')).update(name).digest('base64')
+    return mac === entry.hashed.hash
+  }
+  return patternsMatch(entry.patterns, name)
+}
+
+export interface OpenSshLookup {
+  // The exact key the server presented is trusted in OpenSSH for this host.
+  trusted: boolean
+  // The host is in known_hosts, but under a different key.
+  knownUnderAnotherKey: boolean
+  // The key is explicitly revoked for this host. Overrides everything else.
+  revoked: boolean
+}
+
+export function lookupInKnownHosts(
+  entries: OpenSshHostEntry[],
+  host: string,
+  port: number,
+  fingerprintOf: (key: Buffer) => string,
+  presentedFingerprint: string
+): OpenSshLookup {
+  const name = canonicalHostname(host, port)
+  const result: OpenSshLookup = { trusted: false, knownUnderAnotherKey: false, revoked: false }
+
+  for (const entry of entries) {
+    if (!entryMatchesHost(entry, name)) continue
+    const sameKey = fingerprintOf(entry.key) === presentedFingerprint
+    if (entry.marker === 'revoked') {
+      if (sameKey) result.revoked = true
+      continue
+    }
+    // A CA entry authorises certificates rather than naming a host key, and
+    // validating a certificate chain is not something this can do. Treat it as
+    // no evidence either way rather than as trust.
+    if (entry.marker === 'cert-authority') continue
+    if (sameKey) result.trusted = true
+    else result.knownUnderAnotherKey = true
+  }
+  return result
+}
+
+export function knownHostsPaths(): string[] {
+  const dir = join(homedir(), '.ssh')
+  return ['known_hosts', 'known_hosts2'].map((f) => join(dir, f)).filter((p) => existsSync(p))
+}
+
+export function readOpenSshKnownHosts(paths = knownHostsPaths()): OpenSshHostEntry[] {
+  const entries: OpenSshHostEntry[] = []
+  for (const path of paths) {
+    try {
+      entries.push(...parseKnownHosts(readFileSync(path, 'utf8')))
+    } catch {
+      // An unreadable known_hosts is not fatal — it only means we fall back to
+      // prompting exactly as before.
+    }
+  }
+  return entries
+}

--- a/tests/approvalVisibility.integration.test.ts
+++ b/tests/approvalVisibility.integration.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+
+import { refreshMcpDataCache } from '../src/main/services/mcpDataCache'
+import { setAssignment, resetPolicyCacheForTests } from '../src/main/services/policyStore'
+import { setMcpConfig, createSession, resetMcpAuthForTests } from '../src/main/services/mcpAuth'
+import { startMcpServer, stopMcpServer } from '../src/main/services/mcpServer'
+import { onApprovalEvent, respondToApproval, listPendingApprovals } from '../src/main/services/approvals'
+
+// An ASK-tier tool call blocks until a human answers it in the app. Before
+// this, the agent got no output whatsoever for the whole approval timeout and
+// reported the tool as hung. These tests pin the two things that stop that:
+// the agent is told an approval is pending, and if nobody answers, the error
+// says where the request was waiting instead of just "timed out".
+const PORT = 58739
+
+const sampleData = {
+  workspaces: [{ id: 'ws-prod', name: 'Production' }],
+  servers: [
+    {
+      id: 's1',
+      workspaceId: 'ws-prod',
+      name: 'Nginx Server Prod',
+      host: '10.0.0.1',
+      port: 22,
+      username: 'root',
+      auth: 'key',
+      os: 'Linux',
+      route: []
+    }
+  ]
+}
+
+let token: string
+
+async function connectedClient(): Promise<Client> {
+  const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${PORT}/mcp`), {
+    requestInit: { headers: { Authorization: `Bearer ${token}` } }
+  })
+  const client = new Client({ name: 'test-client', version: '1.0.0' })
+  await client.connect(transport)
+  return client
+}
+
+describe('a pending approval is visible to the agent', () => {
+  beforeAll(async () => {
+    resetMcpAuthForTests()
+    resetPolicyCacheForTests()
+    refreshMcpDataCache(sampleData)
+    // Read & Write puts writeFiles at 'ask' on both layers, so write_file
+    // reaches the human-approval path rather than being allowed or denied.
+    setAssignment({ level: 'workspace', workspaceId: 'ws-prod' }, 'grp-read-write')
+    setMcpConfig({ enabled: true, port: PORT, approvalTimeoutSeconds: 2 })
+    token = createSession({
+      agentName: 'Test Agent',
+      workspaces: [{ id: 'ws-prod', name: 'Production' }],
+      groupId: 'grp-read-write',
+      groupName: 'Read & Write',
+      ttlMinutes: 60
+    }).token
+    const result = await startMcpServer()
+    expect(result.ok).toBe(true)
+  })
+
+  afterAll(async () => {
+    await stopMcpServer()
+  })
+
+  it('sends a progress notification naming the action, instead of going silent', async () => {
+    const client = await connectedClient()
+    const messages: string[] = []
+
+    // Answer as soon as the notification arrives: that both keeps the test
+    // fast and proves the notification is sent *before* the block, not after.
+    const off = onApprovalEvent((e) => {
+      if (e.type === 'created') setTimeout(() => respondToApproval(e.request.id, 'denied'), 10)
+    })
+
+    try {
+      await client.callTool(
+        { name: 'write_file', arguments: { serverName: 'Nginx Server Prod', path: '/tmp/x', content: 'x' } },
+        undefined,
+        { onprogress: (p) => { if (p.message) messages.push(p.message) } }
+      )
+    } finally {
+      off()
+    }
+
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toContain('Waiting for a human')
+    expect(messages[0]).toContain('Nginx Server Prod')
+    // The word the user actually used when reporting this.
+    expect(messages[0]).toContain('not stuck')
+    await client.close()
+  })
+
+  it('leaves the request pending until a human answers — the agent cannot self-approve', async () => {
+    const client = await connectedClient()
+    let sawPending = false
+    // Denied rather than approved on purpose: approving would let the tool go
+    // on to open a real SSH connection to a host that does not exist, and the
+    // point here is the approval gate, not what happens past it.
+    const off = onApprovalEvent((e) => {
+      if (e.type === 'created') {
+        sawPending = listPendingApprovals().some((r) => r.id === e.request.id)
+        setTimeout(() => respondToApproval(e.request.id, 'denied'), 10)
+      }
+    })
+    try {
+      await client.callTool({
+        name: 'write_file',
+        arguments: { serverName: 'Nginx Server Prod', path: '/tmp/x', content: 'x' }
+      })
+    } finally {
+      // Unsubscribing in a finally matters: a listener leaked by a failing
+      // test auto-answers the *next* test's approval and makes it fail too,
+      // which is exactly how this suite first went wrong.
+      off()
+    }
+    expect(sawPending).toBe(true)
+    await client.close()
+  })
+
+  it('says where the request was waiting when nobody answers it', async () => {
+    const client = await connectedClient()
+    const result = await client.callTool({
+      name: 'write_file',
+      arguments: { serverName: 'Nginx Server Prod', path: '/tmp/x', content: 'x' }
+    })
+    expect(result.isError).toBe(true)
+    const text = (result.content as { type: string; text: string }[])[0].text
+    expect(text).toContain('ShellPilot window')
+    // A timeout the user can act on names the setting that stops it recurring.
+    expect(text).toContain('Ask to Allow')
+    await client.close()
+  }, 10_000)
+
+  it('a denial still reads as a decision, not as a timeout', async () => {
+    const client = await connectedClient()
+    const off = onApprovalEvent((e) => {
+      if (e.type === 'created') setTimeout(() => respondToApproval(e.request.id, 'denied'), 10)
+    })
+    let result
+    try {
+      result = await client.callTool({
+        name: 'write_file',
+        arguments: { serverName: 'Nginx Server Prod', path: '/tmp/x', content: 'x' }
+      })
+    } finally {
+      off()
+    }
+    const text = (result.content as { type: string; text: string }[])[0].text
+    expect(text).toContain('the user rejected')
+    expect(text).not.toContain('timed out')
+    await client.close()
+  })
+})

--- a/tests/opensshKnownHosts.test.ts
+++ b/tests/opensshKnownHosts.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest'
+import { createHash, createHmac, randomBytes } from 'node:crypto'
+
+import {
+  parseKnownHosts,
+  canonicalHostname,
+  entryMatchesHost,
+  lookupInKnownHosts
+} from '../src/main/services/opensshKnownHosts'
+
+const fingerprint = (key: Buffer): string =>
+  `SHA256:${createHash('sha256').update(key).digest('base64').replace(/=+$/, '')}`
+
+const KEY_A = Buffer.from('ssh-rsa-key-material-a')
+const KEY_B = Buffer.from('ssh-rsa-key-material-b')
+const b64 = (b: Buffer): string => b.toString('base64')
+
+function hashHost(name: string): string {
+  const salt = randomBytes(20)
+  const hash = createHmac('sha1', salt).update(name).digest('base64')
+  return `|1|${salt.toString('base64')}|${hash}`
+}
+
+describe('OpenSSH known_hosts parsing', () => {
+  it('skips comments, blank lines and truncated entries', () => {
+    const entries = parseKnownHosts(
+      ['# a comment', '', '   ', 'not-enough-fields', `example.com ssh-rsa ${b64(KEY_A)}`].join('\n')
+    )
+    expect(entries).toHaveLength(1)
+    expect(entries[0].patterns).toEqual(['example.com'])
+    expect(entries[0].keyType).toBe('ssh-rsa')
+    expect(entries[0].key.equals(KEY_A)).toBe(true)
+  })
+
+  it('reads @revoked and @cert-authority markers, and drops unknown ones', () => {
+    const entries = parseKnownHosts(
+      [
+        `@revoked example.com ssh-rsa ${b64(KEY_A)}`,
+        `@cert-authority *.example.com ssh-rsa ${b64(KEY_B)}`,
+        `@some-future-marker example.com ssh-rsa ${b64(KEY_A)}`
+      ].join('\n')
+    )
+    expect(entries.map((e) => e.marker)).toEqual(['revoked', 'cert-authority'])
+  })
+
+  it('accepts a trailing comment after the key', () => {
+    const entries = parseKnownHosts(`example.com ssh-ed25519 ${b64(KEY_A)} zeeshan@laptop`)
+    expect(entries).toHaveLength(1)
+    expect(entries[0].key.equals(KEY_A)).toBe(true)
+  })
+})
+
+describe('host name canonicalisation', () => {
+  // Getting this wrong is the whole bug: a host trusted on a non-default port
+  // is stored as "[host]:port", so looking it up by bare host finds nothing.
+  it('brackets the host only when the port is not 22', () => {
+    expect(canonicalHostname('13.251.230.58', 22000)).toBe('[13.251.230.58]:22000')
+    expect(canonicalHostname('example.com', 22)).toBe('example.com')
+    expect(canonicalHostname('example.com', 0)).toBe('example.com')
+  })
+})
+
+describe('host pattern matching', () => {
+  const entryFor = (hosts: string): ReturnType<typeof parseKnownHosts>[number] =>
+    parseKnownHosts(`${hosts} ssh-rsa ${b64(KEY_A)}`)[0]
+
+  it('matches a plain host and a comma-separated list', () => {
+    expect(entryMatchesHost(entryFor('example.com'), 'example.com')).toBe(true)
+    expect(entryMatchesHost(entryFor('a.com,b.com,c.com'), 'b.com')).toBe(true)
+    expect(entryMatchesHost(entryFor('a.com,b.com'), 'z.com')).toBe(false)
+  })
+
+  it('matches a non-default port only in bracketed form', () => {
+    const entry = entryFor('[13.251.230.58]:22000')
+    expect(entryMatchesHost(entry, '[13.251.230.58]:22000')).toBe(true)
+    expect(entryMatchesHost(entry, '13.251.230.58')).toBe(false)
+  })
+
+  it('supports * and ? wildcards', () => {
+    expect(entryMatchesHost(entryFor('*.example.com'), 'web1.example.com')).toBe(true)
+    expect(entryMatchesHost(entryFor('*.example.com'), 'example.com')).toBe(false)
+    expect(entryMatchesHost(entryFor('web?.example.com'), 'web1.example.com')).toBe(true)
+    expect(entryMatchesHost(entryFor('web?.example.com'), 'web12.example.com')).toBe(false)
+  })
+
+  it('lets a negation override a wildcard match', () => {
+    expect(entryMatchesHost(entryFor('*.example.com,!secret.example.com'), 'secret.example.com')).toBe(false)
+    expect(entryMatchesHost(entryFor('*.example.com,!secret.example.com'), 'web.example.com')).toBe(true)
+  })
+
+  it('does not let a wildcard pattern escape a dot boundary it did not ask for', () => {
+    // "*" is a glob, not a regex — a literal dot in the pattern must stay literal.
+    expect(entryMatchesHost(entryFor('web1.example.com'), 'web1XexampleXcom')).toBe(false)
+  })
+
+  it('matches hashed (HashKnownHosts) entries', () => {
+    const entry = parseKnownHosts(`${hashHost('[13.251.230.58]:22000')} ssh-rsa ${b64(KEY_A)}`)[0]
+    expect(entry.hashed).not.toBeNull()
+    expect(entryMatchesHost(entry, '[13.251.230.58]:22000')).toBe(true)
+    expect(entryMatchesHost(entry, '[13.251.230.58]:22')).toBe(false)
+  })
+})
+
+describe('looking a presented key up in known_hosts', () => {
+  const look = (text: string, host: string, port: number, key: Buffer): ReturnType<typeof lookupInKnownHosts> =>
+    lookupInKnownHosts(parseKnownHosts(text), host, port, fingerprint, fingerprint(key))
+
+  it('recognises the exact key OpenSSH already trusts, on a non-default port', () => {
+    const result = look(`[13.251.230.58]:22000 ssh-rsa ${b64(KEY_A)}`, '13.251.230.58', 22000, KEY_A)
+    expect(result).toEqual({ trusted: true, knownUnderAnotherKey: false, revoked: false })
+  })
+
+  it('reports a host known under a different key rather than calling it trusted', () => {
+    const result = look(`example.com ssh-rsa ${b64(KEY_A)}`, 'example.com', 22, KEY_B)
+    expect(result.trusted).toBe(false)
+    expect(result.knownUnderAnotherKey).toBe(true)
+  })
+
+  it('still recognises the right key when the host has several', () => {
+    // A host normally has one line per key type; matching must not be
+    // defeated by the other types sitting alongside it.
+    const text = [`example.com ssh-rsa ${b64(KEY_A)}`, `example.com ssh-ed25519 ${b64(KEY_B)}`].join('\n')
+    const result = look(text, 'example.com', 22, KEY_B)
+    expect(result.trusted).toBe(true)
+  })
+
+  it('reports revocation for the revoked key', () => {
+    const result = look(`@revoked example.com ssh-rsa ${b64(KEY_A)}`, 'example.com', 22, KEY_A)
+    expect(result.revoked).toBe(true)
+    expect(result.trusted).toBe(false)
+  })
+
+  it('does not treat a CA entry as trust for a host key', () => {
+    // A @cert-authority line authorises certificates; it says nothing about
+    // whether this raw host key is legitimate.
+    const result = look(`@cert-authority *.example.com ssh-rsa ${b64(KEY_A)}`, 'web.example.com', 22, KEY_A)
+    expect(result.trusted).toBe(false)
+    expect(result.knownUnderAnotherKey).toBe(false)
+  })
+
+  it('finds nothing for a host that is genuinely absent', () => {
+    const result = look(`other.com ssh-rsa ${b64(KEY_A)}`, 'example.com', 22, KEY_A)
+    expect(result).toEqual({ trusted: false, knownUnderAnotherKey: false, revoked: false })
+  })
+})


### PR DESCRIPTION
Both symptoms reported as "it's stuck".

## The MCP call that looked hung

An ASK-tier tool call blocks until a human answers it in OpsMaxx. Nothing said so:

- The approval dialog only renders inside the app window — no notification, no dock bounce, no taskbar flash.
- The agent got **no output at all** for the full 120s approval timeout, so the tool looked dead.

Now:

1. A created approval fires a system notification (click focuses the window), bounces the dock on macOS, flashes the taskbar on Windows. The flash clears on resolve.
2. The blocked call sends a progress notification naming the action and server **before** it waits, so the agent can report a pending approval. Clients that sent no `progressToken` get nothing; a failed notification never takes down the call it annotates.
3. A timed-out approval says where the request was waiting and how to stop it recurring.

## The host that prompted despite being trusted

`13.251.230.58:22000` was on line 47 of `~/.ssh/known_hosts` — same key, matching fingerprint. OpsMaxx keeps its own trust store and never read OpenSSH's, so it announced a daily-use host as a stranger.

It reads it now but **does not inherit trust from it**. Adopting that file wholesale would silently take on every decision `accept-new` ever waved through. An entry only changes what the prompt says — recognised host, Trust as the default button — and a human still confirms once.

Two cases are not merely informational:

- **`@revoked`** matching the presented key refuses outright. A negative signal can only restrict, so acting on it without asking is safe.
- **A host under a different key** is called out as either a rebuild or an interception.

`@cert-authority` is ignored — it authorises certificates, which this cannot validate, so it is no evidence rather than trust.

Entries are compared by fingerprinting the key blob, so a match is key *identity*, not key type. Hashed (`HashKnownHosts`) entries and the `[host]:port` form for non-default ports are both handled — the latter is what made the reported host miss.

## Verification

- 331 tests pass, up from 311. 16 new unit tests for the known_hosts reader, 4 new integration tests driving a real MCP client through the approval gate.
- The parser was run against the actual `~/.ssh/known_hosts` on this machine: 111 entries parsed, 8 of them hashed, and the reported host resolves `trusted: true` with its real key and `knownUnderAnotherKey: true` with a bogus one.
- One test initially hung because approving in-test let the tool open a real SSH connection to a fake host, and its leaked listener then auto-answered the next two tests. Both fixed — deny instead of approve, unsubscribe in a `finally`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
