### PR TITLE
Release 0.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shellpilot",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Free, open-source SSH client, SFTP browser, SSH tunnel manager, multi-engine database GUI and encrypted secrets vault in one cross-platform desktop app. A MobaXterm, PuTTY and Termius alternative for Windows, macOS and Linux.",
   "keywords": [
     "ssh",


### PR DESCRIPTION
Version bump for 0.4.4. Contents merged in #13.

**A pending AI approval is now visible.** An ASK-tier MCP call blocks until a human answers it in OpsMaxx, and nothing said so — the dialog renders only inside the app window, and the agent got no output for the full approval timeout. It now fires a system notification, bounces the dock on macOS, flashes the taskbar on Windows, and sends the agent a progress notification naming the action and server before it waits.

**Host key checking reads `~/.ssh/known_hosts`** without inheriting trust from it. A host whose exact key OpenSSH already has is presented as recognised with Trust as the default button; a human still confirms once. `@revoked` refuses outright, a host present under a different key is flagged as rebuild-or-interception, and `@cert-authority` is ignored.

331 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
