### PR TITLE
Fix the two things that broke the 0.6.0 release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,11 @@ jobs:
           name: openvpn-source
           path: .openvpn-src/*.tar.gz
           if-no-files-found: error
+          # The directory starts with a dot, and upload-artifact skips hidden
+          # paths by default — so the tarball was written, found by nobody, and
+          # the release failed on a file that existed. This is the GPL-2.0 §3
+          # corresponding source, so it is not optional.
+          include-hidden-files: true
 
       - name: Verify engine manifest covers this platform
         shell: bash

--- a/scripts/build-openvpn.sh
+++ b/scripts/build-openvpn.sh
@@ -319,6 +319,12 @@ CONFIGURE_FLAGS=(
 # object we fall back to it rather than refusing to build, but say so, because
 # the resulting binary is less portable than the one we intend to ship and the
 # linkage check at the end of this script is what will catch it.
+# Expanded at the call site as ${CAPNG_ARGS[@]+"${CAPNG_ARGS[@]}"} rather than
+# "${CAPNG_ARGS[@]}". Under `set -u`, bash 3.2 treats an empty array's [@]
+# expansion as an unbound variable, and bash 3.2 is what macOS ships — so the
+# plain form built fine on Linux and failed every macOS release with
+# "CAPNG_ARGS[@]: unbound variable". This array is empty on macOS by
+# definition, which is exactly where the old bash is.
 CAPNG_ARGS=()
 if [ "$HOST_OS" != darwin ]; then
   capng_a="$(pkg-config --variable=libdir libcap-ng)/libcap-ng.a"
@@ -338,7 +344,7 @@ build_openvpn() {
     "$SRC/configure" "${CONFIGURE_FLAGS[@]}" \
       OPENSSL_CFLAGS="-I$sslprefix/include" \
       OPENSSL_LIBS="$sslprefix/lib/libssl.a $sslprefix/lib/libcrypto.a" \
-      "${CAPNG_ARGS[@]}" \
+      ${CAPNG_ARGS[@]+"${CAPNG_ARGS[@]}"} \
       CFLAGS="-O2 $archflags" \
       LDFLAGS="$archflags"
     make -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)"


### PR DESCRIPTION
The `v0.6.0` tag built Windows and failed macOS and Linux. Both causes were introduced by the bundling work, and neither could fail anywhere it had already been run.

**macOS — `CAPNG_ARGS[@]: unbound variable`.** Under `set -u`, bash 3.2 treats the `[@]` expansion of an *empty* array as unbound, and bash 3.2 is what macOS ships. The array is empty on macOS by definition (libcap-ng is a Linux dependency), so every macOS build hit it while Linux's bash 5 accepted the identical line. Now expanded as `${CAPNG_ARGS[@]+"${CAPNG_ARGS[@]}"}`.

Verified against `/bin/bash` 3.2 directly, and the full macOS engine build now runs to completion locally — including the new linkage check, which reports the shipped `openvpn` has no dynamic dependencies beyond the base system.

**Linux — the GPL source was written, then not uploaded.** The build produced `.openvpn-src/openvpn-2.6.22-source.tar.gz` and the upload step failed with "No files were found", because the directory starts with a dot and `upload-artifact` skips hidden paths by default. A release failing on a file that exists — and that file is the one that makes distributing OpenVPN lawful. Fixed with `include-hidden-files: true`.

Also cleaning up: the failed run left two duplicate draft releases for the same tag, which will be deleted along with the tag before re-tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)