### PR TITLE
Release 0.6.1: vault orphan on cancel, and a test timeout that hid a flake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shellpilot",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shellpilot",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shellpilot",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Free, open-source SSH client, SFTP browser, SSH tunnel manager, multi-engine database GUI and encrypted secrets vault in one cross-platform desktop app. A MobaXterm, PuTTY and Termius alternative for Windows, macOS and Linux.",
   "keywords": [
     "ssh",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -72,11 +72,10 @@ import {
 } from './services/vpn/manager'
 import { vpnCommitImport, vpnDeleteSecrets, vpnImport } from './services/vpn/import'
 import { wireguardDriver } from './services/vpn/drivers/wireguard'
-import { deleteVpnSecrets, stageImportedSecrets } from './services/vpn/vaultBridge'
+import { mintKeypair, storeKeypair } from './services/vpn/keys'
 import { toVpnResult } from './services/vpn/errors'
 import { withVpnTransport, withVpnTransportDb } from './services/vpn/transport'
-import { isVaultLockedError } from './services/credentialResolver'
-import type { VpnKeygenResult, VpnKind, VpnPublicKeyResult, VpnSpec } from '../shared/vpn'
+import type { VpnKeygenResult, VpnKind, VpnMintResult, VpnPublicKeyResult, VpnSpec } from '../shared/vpn'
 import { externalEditOpen, externalEditStop, externalEditDisposeAll } from './services/extedit'
 import { backupExport, backupImport, backupInspect, deleteAllData, relaunchApp } from './services/backup'
 import { checkForUpdates, getUpdaterStatus, onUpdaterStatus, installUpdate, openReleasePage } from './services/updater'
@@ -575,53 +574,21 @@ ipcMain.handle(
     vpnCommitImport(name, workspaceId, kind, text, baseDir)
 )
 ipcMain.handle('vpn:deleteSecrets', (_e, vaultEntryId: string) => vpnDeleteSecrets(vaultEntryId))
-// A generated WireGuard key takes exactly the road an imported one takes:
-// `stageImportedSecrets` writes it into a `vpn` vault entry and the profile
-// keeps a ref. There is no second storage path — the renderer persists the
-// pointer, never the key.
+// Two channels, because they do two different things to the vault.
 //
-// `privateKey` set means "adopt this one instead of minting one", which is how
-// a key pasted from somewhere else gets stored and how its public half is
-// confirmed at the same time. Neither branch logs: this handler is the only
-// thing between the sidecar and the reply, and it writes nothing anywhere else.
+// `wireguardKeygen` writes; `wireguardMint` does not. The profile form
+// generates through the mint channel and holds the pair, then stores through
+// the other one only if the user presses Save — so cancelling a dialog after
+// pressing "Generate keypair" no longer leaves an entry behind that no profile
+// references. Both bodies live in services/vpn/keys.ts, where the reasoning and
+// the tests for that split are.
+ipcMain.handle('vpn:wireguardMint', (): Promise<VpnMintResult> => mintKeypair())
 ipcMain.handle(
   'vpn:wireguardKeygen',
-  async (
+  (
     _e,
-    req: { profileName: string; workspaceId: string; privateKey?: string; replaces?: string }
-  ): Promise<VpnKeygenResult> => {
-    try {
-      const pasted = req.privateKey?.trim()
-      const pair = await wireguardDriver.keygen(pasted ? { publicKeyFor: pasted } : undefined)
-      const privateKey = pasted || pair.privateKey
-      if (!privateKey) return { ok: false, error: 'No private key was generated.', errorCode: 'internal' }
-      const name = req.profileName.trim() || 'WireGuard'
-      const staged = await stageImportedSecrets(name, req.workspaceId, 'wireguard', { privateKey })
-      // Only once the replacement is safely written. Releasing first would
-      // lose the old key to a vault write that then failed.
-      if (req.replaces && req.replaces !== staged.vaultEntryId) {
-        await deleteVpnSecrets(req.replaces).catch(() => undefined)
-      }
-      return {
-        ok: true,
-        // Returned so the user can reveal and copy the key they just made.
-        // Nothing persists it: the profile carries the ref below instead.
-        privateKey,
-        publicKey: pair.publicKey,
-        privateKeyRef: staged.refs.privateKey,
-        vaultEntryId: staged.vaultEntryId
-      }
-    } catch (e) {
-      if (isVaultLockedError(e)) {
-        return {
-          ok: false,
-          error: 'Unlock the vault before generating a key — this is where it will be stored.',
-          errorCode: 'vault-locked'
-        }
-      }
-      return toVpnResult(e)
-    }
-  }
+    req: { profileName: string; workspaceId: string; privateKey: string; replaces?: string }
+  ): Promise<VpnKeygenResult> => storeKeypair(req)
 )
 // `wg pubkey`, and nothing else: no vault write, no side effect, safe to call
 // while the user is still typing. It exists because a private key is useless

--- a/src/main/services/vpn/keys.ts
+++ b/src/main/services/vpn/keys.ts
@@ -1,0 +1,106 @@
+// Minting a WireGuard keypair, and storing one. Two operations, deliberately
+// not one.
+//
+// ShellPilot mints key material in exactly one place, and this is it. The split
+// below is the whole design: `mintKeypair` makes a pair and touches nothing,
+// `storeKeypair` is the only thing here that writes to the vault. The profile
+// form generates through the first and, if and only if the user presses Save,
+// stores through the second.
+//
+// It used to be a single operation that did both, and the cost was an orphan:
+// open the profile dialog, press "Generate keypair", press Cancel, and a vault
+// entry stayed behind that no profile referenced. The user had asked for a key
+// and then said no.
+//
+// This could equally have been one function with a `store: boolean`. It is not,
+// because a boolean deciding whether a secret is persisted is a boolean that
+// eventually gets passed wrong, and it fails silently in both directions — pass
+// it when you meant to store and the key is lost, omit it and the orphan is
+// back. Two names, no argument to get wrong.
+
+import type { VpnKeygenResult, VpnMintResult } from '../../../shared/vpn'
+import { isVaultLockedError } from '../credentialResolver'
+import { wireguardDriver } from './drivers/wireguard'
+import { toVpnResult } from './errors'
+import { deleteVpnSecrets, stageImportedSecrets } from './vaultBridge'
+
+export interface StoreKeypairRequest {
+  /** Names the vault entry, so key material stays recognisable from the vault
+   *  UI on its own — exactly as an imported profile's entry is. */
+  profileName: string
+  workspaceId: string
+  /** The key to store. Minted here a moment ago, or pasted by the user; by this
+   *  point the difference no longer matters. */
+  privateKey: string
+  /** The entry this profile pointed at before, released once the new one is
+   *  safely written. */
+  replaces?: string
+}
+
+/**
+ * A fresh keypair, stored nowhere.
+ *
+ * The private key crosses IPC to the renderer, which is not new — the caller
+ * has always been able to reveal and copy the key it just made — but nothing
+ * persists it. If the form is cancelled the pair is garbage collected with the
+ * component and no trace of it exists.
+ */
+export async function mintKeypair(): Promise<VpnMintResult> {
+  try {
+    const pair = await wireguardDriver.keygen()
+    if (!pair.privateKey) {
+      return { ok: false, error: 'No private key was generated.', errorCode: 'internal' }
+    }
+    return { ok: true, privateKey: pair.privateKey, publicKey: pair.publicKey }
+  } catch (e) {
+    return toVpnResult(e)
+  }
+}
+
+/**
+ * Store a keypair and hand back the ref the profile should carry.
+ *
+ * Goes through `stageImportedSecrets`, the same function an imported `.conf`
+ * stores through, so there is exactly one road into the vault for a WireGuard
+ * private key rather than a second one that has to be kept in step.
+ *
+ * The public key is derived rather than accepted from the caller. Trusting a
+ * public half sent alongside a private one would let a mismatched pair be
+ * stored and displayed as if it were real, and that is the worst failure
+ * available here: the profile saves, the key looks right on screen, the user
+ * authorises it on their server, and the handshake silently never completes.
+ */
+export async function storeKeypair(req: StoreKeypairRequest): Promise<VpnKeygenResult> {
+  try {
+    const privateKey = req.privateKey.trim()
+    if (!privateKey) {
+      return { ok: false, error: 'No private key was supplied.', errorCode: 'internal' }
+    }
+    const pair = await wireguardDriver.keygen({ publicKeyFor: privateKey })
+    const name = req.profileName.trim() || 'WireGuard'
+    const staged = await stageImportedSecrets(name, req.workspaceId, 'wireguard', { privateKey })
+    // Only once the replacement is safely written. Releasing first would lose
+    // the old key to a vault write that then failed.
+    if (req.replaces && req.replaces !== staged.vaultEntryId) {
+      await deleteVpnSecrets(req.replaces).catch(() => undefined)
+    }
+    return {
+      ok: true,
+      // Returned so the user can reveal and copy the key they just made.
+      // Nothing persists it: the profile carries the ref below instead.
+      privateKey,
+      publicKey: pair.publicKey,
+      privateKeyRef: staged.refs.privateKey,
+      vaultEntryId: staged.vaultEntryId
+    }
+  } catch (e) {
+    if (isVaultLockedError(e)) {
+      return {
+        ok: false,
+        error: 'Unlock the vault before saving this key — this is where it will be stored.',
+        errorCode: 'vault-locked'
+      }
+    }
+    return toVpnResult(e)
+  }
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -29,6 +29,7 @@ import type {
   VpnEngineInfo,
   VpnImportResult,
   VpnKeygenResult,
+  VpnMintResult,
   VpnKind,
   VpnLogLine,
   VpnProfile,
@@ -259,16 +260,24 @@ const api = {
     // made — nothing persists it, and `privateKeyRef` is the only part that
     // goes on the profile.
     //
-    // `privateKey` on the way in means "adopt this instead of minting one",
-    // which is how a key pasted from elsewhere reaches the vault. `replaces`
-    // is the entry this profile pointed at before, released once the new one
-    // is written.
+    // Store a key in the vault and hand back the ref the profile carries.
+    //
+    // `privateKey` is required: this channel no longer mints. Minting moved to
+    // `wireguardMint` below so that generating a key and cancelling the form
+    // leaves nothing behind, which means every call here is a deliberate write.
+    // `replaces` is the entry this profile pointed at before, released once the
+    // new one is safely written.
     wireguardKeygen: (req: {
       profileName: string
       workspaceId: string
-      privateKey?: string
+      privateKey: string
       replaces?: string
     }): Promise<VpnKeygenResult> => ipcRenderer.invoke('vpn:wireguardKeygen', req),
+    // Mint a keypair and store nothing. Separate from `wireguardKeygen` above
+    // because that one writes to the vault: the form generates through this,
+    // holds the pair, and stages it through the other only on Save — so
+    // cancelling a dialog leaves no entry behind.
+    wireguardMint: (): Promise<VpnMintResult> => ipcRenderer.invoke('vpn:wireguardMint'),
     // `wg pubkey`. No vault write and no side effect, so it is safe to call
     // while the user is still typing a key in.
     wireguardPublicKey: (privateKey: string): Promise<VpnPublicKeyResult> =>

--- a/src/renderer/src/components/vpn/VpnProfileForm.tsx
+++ b/src/renderer/src/components/vpn/VpnProfileForm.tsx
@@ -5,6 +5,7 @@ import { useApp } from '../../store/app'
 import { toast } from '../../store/toast'
 import { clsx } from '../../lib/format'
 import { bridgeHas } from '../../lib/bridge'
+import { withVaultUnlock } from '../../lib/withVaultUnlock'
 import { isCidr, isWireGuardKey, parseVpnEndpoint } from '../../../../shared/vpn'
 import { userSuppliesEngine } from '../../../../shared/vpnEngines'
 import type {
@@ -20,6 +21,17 @@ import type {
 } from '../../types'
 import { BindWarning } from './VpnStatusCard'
 import { FrpProxyEditor } from './FrpProxyEditor'
+
+/** A keypair that exists only in this form.
+ *
+ *  Generating or pasting a key used to write it to the vault on the spot, which
+ *  meant opening the dialog, pressing Generate, and pressing Cancel left an
+ *  entry behind that no profile referenced. Cancel has to mean cancel, so the
+ *  pair is held here and written by `save()` or not at all. */
+interface PendingKey {
+  privateKey: string
+  publicKey: string
+}
 
 const listStr = (a: string[] | undefined): string => (a ?? []).join(', ')
 const parseList = (s: string): string[] =>
@@ -102,13 +114,69 @@ export function VpnProfileForm({ profile, onClose, focus }: VpnProfileFormProps)
   // whatever was not.
   const shown = useMemo(() => new Set<string>(), [issues])
 
-  const blocking = issues.filter((i) => i.severity === 'error')
+  // A keypair the user generated or pasted, held here until Save.
+  //
+  // It deliberately does not live on the spec. The spec is plain JSON that gets
+  // persisted, and a private key has no business in it — that is the whole
+  // reason the profile carries a `privateKeyRef` instead. Holding it in form
+  // state means Cancel discards it the way Cancel discards every other edit.
+  const [pendingKey, setPendingKey] = useState<PendingKey | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  // The validator runs in main against the spec, so it cannot know a key is
+  // sitting in this component waiting to be written. Left alone it reports
+  // `private-key-missing`, which is an error, which disables Save — and Save is
+  // precisely the thing that would store the key. Dropping that one issue while
+  // a pending key exists is what makes deferring the write possible at all.
+  const blocking = issues.filter(
+    (i) => i.severity === 'error' && !(pendingKey && i.code === 'private-key-missing')
+  )
   const stripped = draft.spec.strippedDirectives ?? []
 
-  const save = (): void => {
-    if (blocking.length > 0 || !draft.name.trim()) return
-    upsertVpnProfile({ ...draft, name: draft.name.trim() })
-    toast(`${draft.name.trim()} saved`, 'ok')
+  const save = async (): Promise<void> => {
+    if (blocking.length > 0 || !draft.name.trim() || saving) return
+    const name = draft.name.trim()
+    let spec = draft.spec
+
+    // The one write this form performs, and only from here. `stageImportedSecrets`
+    // by way of `wireguardKeygen` — the same road an imported key travels, so
+    // there is still exactly one way a WireGuard private key enters the vault.
+    //
+    // Narrowed on `kind` rather than cast. Only the WireGuard field can set a
+    // pending key, so a cast would be correct today and quietly wrong the day
+    // another engine grows a generated secret — and it would be wrong by
+    // reading a `privateKeyRef` off a spec that has no such field.
+    if (pendingKey && spec.kind === 'wireguard') {
+      const wg: WireGuardSpec = spec
+      setSaving(true)
+      try {
+        const replaces = wg.privateKeyRef?.vaultEntryId
+        const stored = await withVaultUnlock(`Saving the key for ${name}`, () =>
+          Promise.resolve(
+            window.shellpilot?.vpn.wireguardKeygen({
+              profileName: name,
+              workspaceId: draft.workspaceId,
+              privateKey: pendingKey.privateKey,
+              // Released only once the replacement is written, so a profile is
+              // never left pointing at an entry that no longer exists.
+              ...(replaces ? { replaces } : {})
+            })
+          )
+        )
+        if (!stored?.ok || !stored.privateKeyRef) {
+          // The form stays open with the key still held, so the user can fix
+          // whatever went wrong and press Save again rather than losing it.
+          toast(stored?.error ?? 'The key could not be saved to the vault.', 'error')
+          return
+        }
+        spec = { ...wg, privateKeyRef: stored.privateKeyRef }
+      } finally {
+        setSaving(false)
+      }
+    }
+
+    upsertVpnProfile({ ...draft, name, spec })
+    toast(`${name} saved`, 'ok')
     onClose()
   }
 
@@ -133,10 +201,10 @@ export function VpnProfileForm({ profile, onClose, focus }: VpnProfileFormProps)
           </button>
           <button
             className="btn primary sm"
-            disabled={blocking.length > 0 || !draft.name.trim()}
-            onClick={save}
+            disabled={blocking.length > 0 || !draft.name.trim() || saving}
+            onClick={() => void save()}
           >
-            Save
+            {saving ? 'Saving…' : 'Save'}
           </button>
         </>
       }
@@ -166,14 +234,11 @@ export function VpnProfileForm({ profile, onClose, focus }: VpnProfileFormProps)
         {draft.spec.kind === 'wireguard' && (
           <WireGuardFields
             spec={draft.spec}
-            // The vault entry a generated key lands in is named after the
-            // profile, so the key material stays recognisable from the vault
-            // UI on its own — exactly as an imported profile's entry is.
-            profileName={draft.name}
-            workspaceId={draft.workspaceId}
             issue={byPath}
             shown={shown}
             onChange={setSpec}
+            pending={pendingKey}
+            onPending={setPendingKey}
           />
         )}
         {draft.spec.kind === 'openvpn' && (
@@ -399,20 +464,20 @@ function Hint({
 
 interface WgProps {
   spec: WireGuardSpec
-  profileName: string
-  workspaceId: string
   issue: IssueMap
   shown: Set<string>
   onChange: (spec: WireGuardSpec) => void
+  pending: PendingKey | null
+  onPending: (p: PendingKey | null) => void
 }
 
 function WireGuardFields({
   spec,
-  profileName,
-  workspaceId,
   issue,
   onChange,
-  shown
+  shown,
+  pending,
+  onPending
 }: WgProps): React.JSX.Element {
   const systemModeBlocked = useSystemModeBlocked()
   const set = (patch: Partial<WireGuardSpec>): void => onChange({ ...spec, ...patch })
@@ -455,11 +520,10 @@ function WireGuardFields({
 
       <InterfaceKeyField
         spec={spec}
-        profileName={profileName}
-        workspaceId={workspaceId}
         issue={issue}
         shown={shown}
-        onChange={onChange}
+        pending={pending}
+        onPending={onPending}
       />
 
       <label className="field">
@@ -597,11 +661,15 @@ const PUBKEY_DEBOUNCE_MS = 300
 
 interface KeyFieldProps {
   spec: WireGuardSpec
-  profileName: string
-  workspaceId: string
   issue: IssueMap
   shown: Set<string>
-  onChange: (spec: WireGuardSpec) => void
+  /** The pair the form is holding, if any. Written by Save, not by this field.
+   *
+   *  There is no `onChange` here any more, and its absence is the point: this
+   *  field no longer touches the spec. It reports a pair upwards and the form
+   *  decides, on Save, whether a `privateKeyRef` comes into existence. */
+  pending: PendingKey | null
+  onPending: (p: PendingKey | null) => void
 }
 
 /**
@@ -611,10 +679,14 @@ interface KeyFieldProps {
  *
  * The private key is a secret and the profile is plain JSON, so it never lives
  * on the spec — only a `privateKeyRef` into the vault does, exactly as an
- * imported profile's does. Generating and adopting both store the key through
- * `stageImportedSecrets`, the same function an import stores through, and then
- * patch the ref in; the key itself is held here, masked, only so the person who
- * just minted it can copy it once for their own records.
+ * imported profile's does.
+ *
+ * This field writes nothing. It mints, it derives, it hands the pair up to the
+ * form, and the form writes it on Save through the same `stageImportedSecrets`
+ * road an import travels. That split exists because the old arrangement stored
+ * on the button press: opening the dialog, pressing Generate and pressing
+ * Cancel left a vault entry no profile referenced. Cancel now discards the key
+ * along with every other unsaved edit, which is what Cancel is for.
  *
  * The public key is the whole point. A private key nobody can get the public
  * half out of is a key you cannot use: it is what the server's `[Peer]` section
@@ -630,27 +702,26 @@ interface KeyFieldProps {
  */
 function InterfaceKeyField({
   spec,
-  profileName,
-  workspaceId,
   issue,
   shown,
-  onChange
+  pending,
+  onPending
 }: KeyFieldProps): React.JSX.Element {
-  const [privateKey, setPrivateKey] = useState('')
+  const [privateKey, setPrivateKey] = useState(pending?.privateKey ?? '')
   const [reveal, setReveal] = useState(false)
-  const [publicKey, setPublicKey] = useState('')
-  // The public half of whatever is in the vault right now, when this session
-  // is what put it there. Distinguishes "typed but not stored" from "stored".
-  const [storedPublicKey, setStoredPublicKey] = useState('')
+  const [publicKey, setPublicKey] = useState(pending?.publicKey ?? '')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const bridge = window.shellpilot?.vpn as Record<string, unknown> | undefined
-  const canKeygen = bridgeHas(bridge, 'wireguardKeygen')
+  const canMint = bridgeHas(bridge, 'wireguardMint')
   const canDerive = bridgeHas(bridge, 'wireguardPublicKey')
   const shaped = isWireGuardKey(privateKey)
   const inVault = !!spec.privateKeyRef?.vaultEntryId
-  const dirty = shaped && publicKey !== '' && publicKey !== storedPublicKey
+  // A usable key on screen that the form is not yet holding. Compared against
+  // the pending pair rather than against the vault, because "will be saved" is
+  // now the state that matters and the vault has not been touched.
+  const dirty = shaped && publicKey !== '' && publicKey !== pending?.publicKey
 
   // Live `wg pubkey` while the user pastes. Cheap enough to run on a settled
   // keystroke and the only way the field is worth having.
@@ -672,36 +743,34 @@ function InterfaceKeyField({
     }
   }, [privateKey, shaped, canDerive])
 
-  /** Mint or adopt, store, and point the profile at what was stored. */
-  const stage = async (paste: string | undefined): Promise<void> => {
-    if (!canKeygen || busy) return
+  /** Mint a fresh pair. Nothing is stored — the form writes it on Save. */
+  const mint = async (): Promise<void> => {
+    if (!canMint || busy) return
     setBusy(true)
     setError(null)
     try {
-      const res = await window.shellpilot?.vpn.wireguardKeygen({
-        profileName,
-        workspaceId,
-        ...(paste ? { privateKey: paste } : {}),
-        // Released only once the replacement is written, so a profile is never
-        // left pointing at an entry that no longer exists.
-        ...(spec.privateKeyRef?.vaultEntryId ? { replaces: spec.privateKeyRef.vaultEntryId } : {})
-      })
-      if (!res?.ok || !res.privateKeyRef || !res.publicKey) {
-        setError(res?.error ?? 'The key could not be stored.')
+      const res = await window.shellpilot?.vpn.wireguardMint()
+      if (!res?.ok || !res.privateKey || !res.publicKey) {
+        setError(res?.error ?? 'The key could not be generated.')
         return
       }
-      // The key is shown so it can be copied once; it is the ref that is saved.
-      setPrivateKey(res.privateKey ?? paste ?? '')
+      setPrivateKey(res.privateKey)
       setPublicKey(res.publicKey)
-      setStoredPublicKey(res.publicKey)
       // Not revealed on arrival: a freshly generated key on screen is a key on
       // screen, and the eye is right there for the moment it is wanted.
       setReveal(false)
-      onChange({ ...spec, privateKeyRef: res.privateKeyRef })
-      toast(paste ? 'Private key saved to the vault' : 'Keypair generated', 'ok')
+      onPending({ privateKey: res.privateKey, publicKey: res.publicKey })
     } finally {
       setBusy(false)
     }
+  }
+
+  /** Take the key in the box. No IPC: its public half was already derived live
+   *  by the effect above, which is the only thing adopting ever needed. */
+  const adopt = (): void => {
+    if (!shaped || publicKey === '') return
+    setError(null)
+    onPending({ privateKey, publicKey })
   }
 
   return (
@@ -709,7 +778,7 @@ function InterfaceKeyField({
       <div className="row" style={{ gap: 8 }}>
         <span className="field-label">Interface key</span>
         <span className="grow" />
-        <button className="btn sm" disabled={!canKeygen || busy} onClick={() => void stage(undefined)}>
+        <button className="btn sm" disabled={!canMint || busy} onClick={() => void mint()}>
           <KeyRound size={13} /> Generate keypair
         </button>
       </div>
@@ -724,8 +793,17 @@ function InterfaceKeyField({
           placeholder={inVault ? 'Paste a private key to replace the stored one' : 'Paste a private key, or generate one'}
           value={privateKey}
           onChange={(e) => {
+            const next = e.target.value.trim()
             setError(null)
-            setPrivateKey(e.target.value.trim())
+            setPrivateKey(next)
+            // Emptying the box drops the held key.
+            //
+            // Otherwise the form goes on holding a pair the field no longer
+            // shows, and Save writes a key the user has visibly deleted. This
+            // is not the old behaviour — clearing the box could not unstore a
+            // key that was already in the vault — but nothing is in the vault
+            // yet, so the honest reading of an empty box is "not this one".
+            if (next === '' && pending) onPending(null)
           }}
         />
         <button
@@ -753,14 +831,26 @@ function InterfaceKeyField({
 
       {dirty && (
         <div className="row" style={{ gap: 6 }}>
-          <button className="btn primary sm" disabled={busy} onClick={() => void stage(privateKey)}>
-            {inVault ? 'Replace the stored key' : 'Save this key to the vault'}
+          <button className="btn primary sm" disabled={busy} onClick={adopt}>
+            {inVault ? 'Replace the stored key' : 'Use this key'}
           </button>
           <span className="field-hint">
             Until you do, this profile still uses{' '}
             {inVault ? 'the key already in the vault' : 'no key at all'}.
           </span>
         </div>
+      )}
+
+      {pending !== null && !dirty && (
+        // The state that did not exist before: a real key, held, not yet
+        // written. Saying so plainly is the price of deferring the write — a
+        // user who generated a key and closed the window has to be able to tell
+        // whether they have one.
+        <span className="field-hint">
+          {inVault
+            ? 'This key replaces the stored one when you press Save.'
+            : 'This key is saved to the vault when you press Save.'}
+        </span>
       )}
 
       {publicKey !== '' && (
@@ -796,17 +886,20 @@ function InterfaceKeyField({
       )}
 
       <span className="field-hint">
-        {!canKeygen
+        {!canMint
           ? 'This build cannot generate keys. Import a .conf that already carries one.'
           : dirty
-            ? // The dirty row above already says what to do about it; repeating
+            ? // The row above already says what to do about it; repeating
               // "stored in the vault" here would be a straight contradiction.
               'Nothing is written to the vault until you say so.'
-            : privateKey !== ''
-              ? 'Held in the vault. The private key is never written to this profile, to a config file, or to a log line.'
+            : pending !== null
+              ? // Deliberately not "held in the vault", which is what this said
+                // when the write happened on the button press. It is held here,
+                // in an unsaved form, and Cancel throws it away.
+                'The private key goes to the vault on Save, and never onto this profile, a config file, or a log line.'
               : inVault
                 ? 'Private key, held in the vault. ShellPilot cannot read it back to show you its public key — paste the key here to see it, or generate a new pair and authorise that one instead.'
-                : 'No private key yet. Generate a pair, or paste one you already have; either way it goes to the vault and the profile keeps only a pointer to it.'}
+                : 'No private key yet. Generate a pair, or paste one you already have; either way it goes to the vault on Save and the profile keeps only a pointer to it.'}
       </span>
     </div>
   )

--- a/src/shared/vpn.ts
+++ b/src/shared/vpn.ts
@@ -346,7 +346,7 @@ export interface VpnImportResultInternal extends VpnImportResult {
 // ------------------------------------------------------------- key material
 
 // A WireGuard keypair is the one place ShellPilot mints a secret rather than
-// being handed one, so these two shapes are separate on purpose.
+// being handed one, so these shapes are separate on purpose.
 //
 // `VpnKeygenResult` carries a private key and therefore never leaves the
 // machine, but it does cross IPC: the user has to be able to reveal and copy
@@ -354,6 +354,23 @@ export interface VpnImportResultInternal extends VpnImportResult {
 // bodies in the other direction during an import. `VpnPublicKeyResult` carries
 // nothing secret at all and is what the live "what is the public half of this?"
 // preview uses.
+//
+// `VpnMintResult` is the third: a keypair that has been made and *not* stored.
+// The distinction is in the type rather than in a boolean parameter, because
+// "did this write a secret to the vault" is exactly the question a reader
+// should be able to answer from the call site. The absence of `privateKeyRef`
+// here is the whole point — there is no ref because there is nothing to point
+// at yet, and the form does not create one until the user presses Save.
+
+export interface VpnMintResult {
+  ok: boolean
+  error?: string
+  errorCode?: VpnErrorCode
+  // base64. Held in the form, shown masked, and lost if the form is cancelled.
+  privateKey?: string
+  // base64. The half the user gives to their server or their provider.
+  publicKey?: string
+}
 
 export interface VpnKeygenResult {
   ok: boolean

--- a/tests/vpnKeyStaging.test.ts
+++ b/tests/vpnKeyStaging.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { VaultEntry } from '../src/shared/vault'
+
+// Generating a WireGuard key must not store one.
+//
+// The profile form offers "Generate keypair" inside a dialog with a Cancel
+// button, and it used to write the key to the vault the moment that button was
+// pressed. Press Generate, change your mind, press Cancel, and an entry stayed
+// behind that no profile referenced — the user had asked for a key and then
+// said no, and got one anyway. Cosmetic rather than a leak, since it was
+// visible in the vault UI and repeated generates replaced rather than
+// accumulated, but wrong.
+//
+// The fix splits one operation into two: `mintKeypair` makes a pair and touches
+// nothing, `storeKeypair` writes. These tests are about that boundary, so the
+// assertion that matters most is a negative one — after minting, the vault is
+// exactly as it was.
+//
+// The vault here is the real `vaultBridge` over a fake store, not a stub of the
+// bridge itself. A test that mocked the writing function and then asserted the
+// mock was not called would pass just as happily if the code had found some
+// other way to write.
+
+let vaultEntries: VaultEntry[] = []
+let vaultUnlocked = true
+
+vi.mock('../src/main/services/secrets', () => ({
+  getSecret: () => null,
+  setSecret: () => undefined
+}))
+
+vi.mock('../src/main/services/vault', () => ({
+  vaultStatus: () => ({ exists: true, unlocked: vaultUnlocked, entryCount: vaultEntries.length }),
+  vaultList: () =>
+    vaultUnlocked ? { ok: true, entries: vaultEntries } : { ok: false, error: 'Vault is locked.' },
+  vaultSave: (entries: VaultEntry[]) => {
+    if (!vaultUnlocked) return { ok: false, error: 'Vault is locked.' }
+    vaultEntries = entries
+    return { ok: true }
+  }
+}))
+
+// Real-shaped material: 44-char base64, so nothing downstream rejects it for
+// the wrong reason.
+const PRIV_A = 'yAnz5TF+lXXJte14tji3zlMNq+hd2rYUIgJBgB3fBmk='
+const PUB_A = 'xTIBA5rboUvnH4htodjb6e697QjLERt1NAB4mZqp8Dg='
+const PRIV_B = 'aFpCyhws9cxwWoV4xELtfJvjJN+zQVRPISllRWgeopU='
+const PUB_B = 'pkPvgzKnI5aurLXke0Gm5mrEX12B/I025l5wMfdPolI='
+
+const keygen = vi.fn(async (params?: { publicKeyFor?: string }) => {
+  // Mirrors the sidecar: with a private key it derives, without one it mints.
+  if (params?.publicKeyFor) {
+    return { publicKey: params.publicKeyFor === PRIV_B ? PUB_B : PUB_A }
+  }
+  return { privateKey: PRIV_A, publicKey: PUB_A }
+})
+
+vi.mock('../src/main/services/vpn/drivers/wireguard', () => ({
+  wireguardDriver: { keygen: (p?: { publicKeyFor?: string }) => keygen(p) }
+}))
+
+const { mintKeypair, storeKeypair } = await import('../src/main/services/vpn/keys')
+
+const vpnEntries = (): VaultEntry[] => vaultEntries.filter((e) => e.kind === 'vpn')
+
+beforeEach(() => {
+  vaultEntries = []
+  vaultUnlocked = true
+  keygen.mockClear()
+})
+
+describe('generating a key', () => {
+  it('hands back a usable pair', async () => {
+    const res = await mintKeypair()
+    expect(res.ok).toBe(true)
+    expect(res.privateKey).toBe(PRIV_A)
+    expect(res.publicKey).toBe(PUB_A)
+  })
+
+  it('writes nothing to the vault', async () => {
+    // The bug, stated as a test. Before the split this call left an entry.
+    await mintKeypair()
+    expect(vaultEntries).toEqual([])
+  })
+
+  it('still writes nothing after the user generates several times', async () => {
+    // Someone deciding they do not like the look of a key and pressing the
+    // button again is ordinary behaviour, not misuse.
+    await mintKeypair()
+    await mintKeypair()
+    await mintKeypair()
+    expect(vaultEntries).toEqual([])
+  })
+
+  it('reports a sidecar that answers without a private key rather than storing a blank', async () => {
+    keygen.mockResolvedValueOnce({ publicKey: PUB_A } as { privateKey?: string; publicKey: string })
+    const res = await mintKeypair()
+    expect(res.ok).toBe(false)
+    expect(vaultEntries).toEqual([])
+  })
+})
+
+describe('generate, then cancel', () => {
+  it('leaves no vault entry behind', async () => {
+    // The whole point, end to end at this boundary: the form mints, the user
+    // presses Cancel, and `storeKeypair` is simply never reached. There is no
+    // cleanup path to get wrong because there is nothing to clean up.
+    const minted = await mintKeypair()
+    expect(minted.ok).toBe(true)
+
+    // …Cancel. Nothing else happens.
+
+    expect(vpnEntries()).toHaveLength(0)
+    expect(vaultEntries).toEqual([])
+  })
+})
+
+describe('generate, then save', () => {
+  it('stores exactly one entry and returns the ref the profile keeps', async () => {
+    const minted = await mintKeypair()
+    const stored = await storeKeypair({
+      profileName: 'Office WireGuard',
+      workspaceId: 'w1',
+      privateKey: minted.privateKey!
+    })
+
+    expect(stored.ok).toBe(true)
+    expect(stored.privateKeyRef?.vaultEntryId).toBe(stored.vaultEntryId)
+    expect(vpnEntries()).toHaveLength(1)
+  })
+
+  it('names the entry after the profile, so it is recognisable in the vault UI', async () => {
+    await storeKeypair({ profileName: 'Office WireGuard', workspaceId: 'w1', privateKey: PRIV_A })
+    expect(vpnEntries()[0].name).toContain('Office WireGuard')
+  })
+
+  it('falls back to a name rather than storing an untitled entry', async () => {
+    await storeKeypair({ profileName: '   ', workspaceId: 'w1', privateKey: PRIV_A })
+    expect(vpnEntries()[0].name.trim()).not.toBe('')
+  })
+
+  it('derives the public key instead of trusting one it was handed', async () => {
+    // A stored pair whose halves do not match is the worst outcome available
+    // here: it saves, it looks right on screen, the user authorises it on their
+    // server, and the handshake silently never completes. So the public half is
+    // computed from the private one at the point of storage.
+    await storeKeypair({ profileName: 'p', workspaceId: 'w1', privateKey: PRIV_B })
+    expect(keygen).toHaveBeenCalledWith({ publicKeyFor: PRIV_B })
+  })
+})
+
+describe('replacing a stored key', () => {
+  it('releases the old entry once the new one is written', async () => {
+    const first = await storeKeypair({ profileName: 'p', workspaceId: 'w1', privateKey: PRIV_A })
+    expect(vpnEntries()).toHaveLength(1)
+
+    const second = await storeKeypair({
+      profileName: 'p',
+      workspaceId: 'w1',
+      privateKey: PRIV_B,
+      replaces: first.vaultEntryId
+    })
+
+    expect(second.ok).toBe(true)
+    expect(vpnEntries().map((e) => e.id)).toEqual([second.vaultEntryId])
+  })
+
+  it('keeps the old entry when the new one could not be written', async () => {
+    // Releasing first would lose a working key to a write that then failed,
+    // which is the one outcome here worse than an orphan.
+    const first = await storeKeypair({ profileName: 'p', workspaceId: 'w1', privateKey: PRIV_A })
+    vaultUnlocked = false
+
+    const second = await storeKeypair({
+      profileName: 'p',
+      workspaceId: 'w1',
+      privateKey: PRIV_B,
+      replaces: first.vaultEntryId
+    })
+
+    expect(second.ok).toBe(false)
+    vaultUnlocked = true
+    expect(vpnEntries().map((e) => e.id)).toEqual([first.vaultEntryId])
+  })
+})
+
+describe('a locked vault', () => {
+  it('is reported as vault-locked, so the form can offer to unlock it', async () => {
+    // `withVaultUnlock` in the renderer keys off this exact code. Anything else
+    // and Save fails with advice the user has no way to act on.
+    vaultUnlocked = false
+    const res = await storeKeypair({ profileName: 'p', workspaceId: 'w1', privateKey: PRIV_A })
+    expect(res.ok).toBe(false)
+    expect(res.errorCode).toBe('vault-locked')
+  })
+
+  it('does not stop a key being generated, because generating stores nothing', async () => {
+    // Worth pinning: the old combined operation had to fail here, since it
+    // wrote. Making the user unlock the vault before they can even see what a
+    // key looks like is a prompt for no reason.
+    vaultUnlocked = false
+    const res = await mintKeypair()
+    expect(res.ok).toBe(true)
+    expect(res.publicKey).toBe(PUB_A)
+  })
+})

--- a/tests/vpnWireguardDriver.test.ts
+++ b/tests/vpnWireguardDriver.test.ts
@@ -63,6 +63,30 @@ if (!HAVE_NETD) {
   console.warn(`[vpnWireguardDriver] ${NETD_PATH} is missing; run scripts/build-sidecar.sh. Integration tests skipped.`)
 }
 
+/**
+ * How long a test that drives two real WireGuard devices may take.
+ *
+ * This has to exceed the driver's own `firstHandshakeTimeoutMs`, and that is
+ * the entire point of it existing. vitest's global `testTimeout` is 15 s; the
+ * beforeEach below deliberately gives the driver 25 s to see a first handshake,
+ * because under a parallel suite two real devices occasionally need longer than
+ * the 8 s it used to allow.
+ *
+ * Those two numbers were in the wrong order, and the effect was worse than
+ * either alone. A handshake slower than 15 s could not succeed — vitest killed
+ * the test first — and it could not fail usefully either, because the driver's
+ * own error, the one that names the endpoint, the UDP port and the peer key
+ * (E22/E27), was not due for another ten seconds. All that survived was
+ * `Test timed out in 15000ms`, pointing at whichever test happened to be
+ * running. That is why this flake outlived two attempts to diagnose it: the
+ * budget raise landed, and the executioner's clock was never moved to match.
+ *
+ * Kept comfortably above the driver's budget rather than equal to it, so the
+ * driver always loses the race and gets to explain itself. `guards the
+ * handshake budget` below fails if the order is ever inverted again.
+ */
+const REAL_SIDECAR_TIMEOUT_MS = 40_000
+
 const SERVER_IP = '10.7.0.2'
 const CLIENT_IP = '10.7.0.1'
 // Nothing listens here inside the peer's netstack, which is the point: the
@@ -119,6 +143,12 @@ interface PeerReply {
 class PeerNode {
   private seq = 0
   private readonly pending = new Map<string, (r: PeerReply) => void>()
+  private readonly rejects = new Map<string, (e: Error) => void>()
+  /** Everything the peer said on stderr, kept so a failure can quote it.
+   *  Also drained rather than ignored: an unread pipe fills at 64 KB and the
+   *  writer blocks there, which would be a hang caused by the harness. */
+  private stderr = ''
+  private died: string | null = null
 
   private constructor(
     private readonly child: ChildProcess,
@@ -126,18 +156,77 @@ class PeerNode {
     readonly publicKey: string
   ) {}
 
-  static async start(clientPublicKey: string): Promise<PeerNode> {
+  /** Start a peer, retrying when the port it picked is taken.
+   *
+   *  `freeUdpPort` binds port 0, reads the number and closes the socket, so
+   *  what it returns is a port that *was* free. Between that close and the
+   *  sidecar binding it there is a process spawn and a request round trip, and
+   *  under a parallel suite full of sidecars something else occasionally takes
+   *  it — observed here as `wg.up failed: ... bind: address already in use`,
+   *  about once in eighty runs with six copies of this file running at once.
+   *
+   *  The window cannot be closed from the test side: the protocol has no way to
+   *  ask the sidecar to bind an arbitrary free port and report which one it
+   *  got, and adding one to the Go sidecar to suit a test is the wrong trade.
+   *  So losing the race is made harmless instead of impossible. Three attempts
+   *  makes a collision on every one of them vanishingly unlikely, and a
+   *  genuinely broken bind still fails on the last attempt with its real error
+   *  rather than being retried into a timeout. */
+  static async start(clientPublicKey: string, attempt = 1): Promise<PeerNode> {
+    try {
+      return await PeerNode.startOnce(clientPublicKey)
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e)
+      if (attempt < 3 && /address already in use/i.test(message)) {
+        return PeerNode.start(clientPublicKey, attempt + 1)
+      }
+      throw e
+    }
+  }
+
+  private static async startOnce(clientPublicKey: string): Promise<PeerNode> {
     const keys = keypair()
     const port = await freeUdpPort()
     const child = nodeSpawn(NETD_PATH, [], { stdio: ['pipe', 'pipe', 'pipe'] })
     const node = new PeerNode(child, port, keys.publicKey)
 
+    child.stderr?.setEncoding('utf8')
+    child.stderr?.on('data', (c: string) => (node.stderr += c))
+
+    // A peer that dies owes an answer to every call still waiting on it.
+    // Without this the promise simply never settles and the test reports a
+    // bare "timed out in 15000ms" naming whichever test lost the race, with
+    // nothing about the peer at all — which is precisely how this flake stayed
+    // undiagnosed.
+    const abandon = (why: string): void => {
+      node.died = why
+      for (const [id, reject] of node.rejects) {
+        node.pending.delete(id)
+        reject(new Error(`${why}${node.stderr ? `\nstderr: ${node.stderr.trim()}` : ''}`))
+      }
+      node.rejects.clear()
+    }
+    child.on('exit', (code, signal) => {
+      // SIGKILL is `stop()` doing its job at the end of a test.
+      if (signal !== 'SIGKILL') abandon(`peer sidecar exited: code=${code} signal=${signal}`)
+    })
+    child.on('error', (e) => abandon(`peer sidecar could not be started: ${e.message}`))
+
     createInterface({ input: child.stdout!, crlfDelay: Infinity }).on('line', (line) => {
       if (!line.startsWith('{')) return
-      const msg = JSON.parse(line) as PeerReply & { id?: string }
+      let msg: PeerReply & { id?: string }
+      try {
+        msg = JSON.parse(line) as PeerReply & { id?: string }
+      } catch {
+        // Throwing in here is an unhandled exception in a readline callback,
+        // which takes the whole worker down rather than failing one test.
+        node.stderr += `\nunparseable stdout line: ${line}`
+        return
+      }
       if (typeof msg.id === 'string') {
         const done = node.pending.get(msg.id)
         node.pending.delete(msg.id)
+        node.rejects.delete(msg.id)
         done?.(msg)
       }
     })
@@ -157,15 +246,56 @@ class PeerNode {
       peers: [{ publicKey: clientPublicKey, endpoint: '', allowedIps: [`${CLIENT_IP}/32`] }],
       listeners: []
     })
-    if (!up.ok) throw new Error(`peer wg.up failed: ${up.error?.message}`)
+    if (!up.ok) {
+      // Reap it before retrying, or a losing attempt leaves a live sidecar
+      // behind for the rest of the file.
+      child.kill('SIGKILL')
+      throw new Error(`peer wg.up failed: ${up.error?.message}`)
+    }
     return node
   }
 
-  call(method: string, params?: unknown): Promise<PeerReply> {
+  /** Ask the peer something, and fail rather than wait forever.
+   *
+   *  The budget is below vitest's per-test timeout on purpose: a call that
+   *  gives up first can say which method hung and what the peer printed, where
+   *  the test timeout can only say that fifteen seconds passed. */
+  call(method: string, params?: unknown, ms = 10_000): Promise<PeerReply> {
     const id = String(++this.seq)
-    return new Promise((resolve) => {
-      this.pending.set(id, resolve)
-      this.child.stdin!.write(`${JSON.stringify({ id, method, params })}\n`)
+    return new Promise((resolve, reject) => {
+      if (this.died) {
+        reject(new Error(`${this.died} (before ${method})`))
+        return
+      }
+      const timer = setTimeout(() => {
+        this.pending.delete(id)
+        this.rejects.delete(id)
+        reject(
+          new Error(
+            `peer never answered ${method} within ${ms}ms` +
+              `${this.stderr ? `\nstderr: ${this.stderr.trim()}` : ''}`
+          )
+        )
+      }, ms)
+      this.pending.set(id, (r) => {
+        clearTimeout(timer)
+        resolve(r)
+      })
+      this.rejects.set(id, (e) => {
+        clearTimeout(timer)
+        reject(e)
+      })
+      this.child.stdin!.write(`${JSON.stringify({ id, method, params })}\n`, (err) => {
+        // An EPIPE here means the peer is already gone. Reported rather than
+        // swallowed, because the alternative is waiting out the timeout for a
+        // process that will never read the request.
+        if (err) {
+          this.pending.delete(id)
+          this.rejects.delete(id)
+          clearTimeout(timer)
+          reject(new Error(`could not send ${method} to the peer: ${err.message}`))
+        }
+      })
     })
   }
 
@@ -1038,6 +1168,41 @@ describe('system mode', () => {
 
 // ================================================================ engine I/O
 
+// Not gated on the sidecar being built: this is a relationship between two
+// numbers, it costs nothing to check, and a checkout without the sidecar is
+// exactly where someone edits a timeout without being able to run the tests
+// that would notice.
+describe('timeout budgets', () => {
+  it('guards the handshake budget against the test timeout that kills it', () => {
+    // The invariant this whole file's stability rests on, asserted rather than
+    // remembered.
+    //
+    // The driver is allowed to wait `firstHandshakeTimeoutMs` for two real
+    // devices to complete a Noise handshake. If the harness kills the test
+    // before that budget expires, a slow handshake can neither succeed nor
+    // report why it failed: what surfaces is a bare `Test timed out`, naming
+    // whichever test drew the short straw and saying nothing about WireGuard.
+    // That is exactly what happened when the budget was raised from 8 s to 25 s
+    // and vitest's 15 s `testTimeout` was left behind, and it cost two
+    // investigations that both concluded "undiagnosed".
+    //
+    // Revert `REAL_SIDECAR_TIMEOUT_MS` to the global 15 s and this fails here,
+    // immediately and by name, instead of intermittently and anonymously
+    // somewhere else.
+    expect(
+      REAL_SIDECAR_TIMEOUT_MS,
+      'the per-test timeout must outlast the driver\'s first-handshake budget, ' +
+        'or the driver never gets to report a handshake-timeout'
+    ).toBeGreaterThan(wireguardTuning.firstHandshakeTimeoutMs)
+
+    // And with room to spare: the test also has to start a peer sidecar and run
+    // its assertions after the handshake lands.
+    expect(REAL_SIDECAR_TIMEOUT_MS - wireguardTuning.firstHandshakeTimeoutMs).toBeGreaterThanOrEqual(
+      10_000
+    )
+  })
+})
+
 describe.skipIf(!HAVE_NETD)('probe', () => {
   it('finds and hashes the bundled sidecar and reports a readable version', async () => {
     const info = await wireguardDriver.probe()
@@ -1103,7 +1268,7 @@ describe.skipIf(!HAVE_NETD)('start, over a real handshake', () => {
       targetHost: SERVER_IP,
       targetPort: CLOSED_PORT
     })
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 
   it('sends every key on stdin and puts nothing on argv or in the environment', async () => {
     await startConnected()
@@ -1121,7 +1286,7 @@ describe.skipIf(!HAVE_NETD)('start, over a real handshake', () => {
     // happened.
     expect(stdinWrites.join('')).toContain(client.privateKey)
     expect(stdinWrites.join('')).toContain('"wg.up"')
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 
   it('reports live stats with a handshake age computed from the pinned clock', async () => {
     await startConnected()
@@ -1136,7 +1301,7 @@ describe.skipIf(!HAVE_NETD)('start, over a real handshake', () => {
     expect(stats?.txBytes).toBeGreaterThan(0)
     expect(stats?.rxBytes).toBeGreaterThan(0)
     expect(wireguardDriver.status(PROFILE_ID)?.state).toBe('connected')
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 
   it('calls a stale handshake degraded, not error (the 180 s boundary)', async () => {
     // The pinned clock is set 400 s ahead of the sidecar's, so the handshake
@@ -1155,7 +1320,7 @@ describe.skipIf(!HAVE_NETD)('start, over a real handshake', () => {
     expect(status?.errorCode).toBe('handshake-timeout')
     expect(status?.error).toMatch(new RegExp(`over ${WG_HANDSHAKE_STALE_SEC}s`))
     expect(status?.error).toMatch(/still up/i)
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 
   it('clamps the age at zero when the clock says the handshake is in the future (E63)', async () => {
     const realNow = Date.now()
@@ -1168,7 +1333,7 @@ describe.skipIf(!HAVE_NETD)('start, over a real handshake', () => {
     expect(stats?.lastHandshakeSec).toBe(0)
     expect(stats?.lastHandshakeSec).not.toBeLessThan(0)
     expect(wireguardDriver.status(PROFILE_ID)?.state).toBe('connected')
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 
   it('carries a SOCKS5 conversation and dials through the tunnel', async () => {
     await startConnected()
@@ -1193,7 +1358,7 @@ describe.skipIf(!HAVE_NETD)('start, over a real handshake', () => {
     const after = await peerCounters()
     expect(after.rxBytes).toBeGreaterThan(before.rxBytes)
     expect(after.txBytes).toBeGreaterThan(before.txBytes)
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 
   it('accepts a connection on a forward listener and fails the dial cleanly', async () => {
     await startConnected({
@@ -1211,7 +1376,7 @@ describe.skipIf(!HAVE_NETD)('start, over a real handshake', () => {
 
     const after = await peerCounters()
     expect(after.rxBytes).toBeGreaterThan(before.rxBytes)
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 
   it('opens and closes an ephemeral forward', async () => {
     await startConnected()
@@ -1235,7 +1400,7 @@ describe.skipIf(!HAVE_NETD)('start, over a real handshake', () => {
         return (e as NodeJS.ErrnoException).code === 'ECONNREFUSED'
       }
     })
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 
   it('tears everything down on stop and leaves no listener behind', async () => {
     await startConnected({
@@ -1262,7 +1427,7 @@ describe.skipIf(!HAVE_NETD)('start, over a real handshake', () => {
       })
       await new Promise<void>((resolve) => srv.close(() => resolve()))
     }
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 
   it('sends wg.down before shutdown so the ports are free before the process goes', async () => {
     await startConnected()
@@ -1272,7 +1437,7 @@ describe.skipIf(!HAVE_NETD)('start, over a real handshake', () => {
     expect(written).toContain('"wg.down"')
     expect(written).toContain('"shutdown"')
     expect(written.indexOf('"wg.down"')).toBeLessThan(written.indexOf('"shutdown"'))
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 })
 
 describe.skipIf(!HAVE_NETD)('failures the user can act on', () => {
@@ -1301,7 +1466,7 @@ describe.skipIf(!HAVE_NETD)('failures the user can act on', () => {
     expect(spawns).toHaveLength(1)
     expect(supervisor.get(PROFILE_ID)).toBeUndefined()
     await waitFor('the sidecar to exit', () => children[0].exitCode !== null || children[0].signalCode !== null)
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 
   it('names the port that is already in use (E24)', async () => {
     const taken = await occupyPort()
@@ -1318,7 +1483,7 @@ describe.skipIf(!HAVE_NETD)('failures the user can act on', () => {
     expect(result.error).toContain(String(taken))
     expect(result.error).toMatch(/leave it as 0/i)
     expect(supervisor.get(PROFILE_ID)).toBeUndefined()
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 
   it('reports a non-loopback bind back verbatim so the UI can warn (E25)', async () => {
     peer = await PeerNode.start(client.publicKey)
@@ -1334,7 +1499,7 @@ describe.skipIf(!HAVE_NETD)('failures the user can act on', () => {
     // hiding a LAN-visible proxy.
     expect(result.listeners?.[0].bindHost).toBe('0.0.0.0')
     expect(logs.some((l) => /reachable from your local network/i.test(l))).toBe(true)
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 
   it('refuses a profile whose key never made it out of the vault', async () => {
     peer = await PeerNode.start(client.publicKey)
@@ -1344,7 +1509,7 @@ describe.skipIf(!HAVE_NETD)('failures the user can act on', () => {
     expect(result.ok).toBe(false)
     expect(result.errorCode).toBe('config-invalid')
     expect(supervisor.get(PROFILE_ID)).toBeUndefined()
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 
   it('returns null stats and no forward for a profile that is not running', async () => {
     expect(await wireguardDriver.stats(PROFILE_ID)).toBeNull()
@@ -1352,7 +1517,7 @@ describe.skipIf(!HAVE_NETD)('failures the user can act on', () => {
     await expect(wireguardDriver.openForward!(PROFILE_ID, SERVER_IP, CLOSED_PORT)).rejects.toMatchObject({
       code: 'internal'
     })
-  })
+  }, REAL_SIDECAR_TIMEOUT_MS)
 })
 
 // Accepts an async predicate too: some conditions can only be observed by


### PR DESCRIPTION
Two fixes on top of 0.6.0, one user-visible and one that keeps the suite honest.

## Generating a keypair no longer writes a key you then cancel

The WireGuard profile form stored a generated private key the moment the button was pressed. Open the dialog, press Generate, press Cancel, and a vault entry stayed behind that no profile referenced — the user asked for a key and then said no, and got one anyway.

One operation became two: `mintKeypair` makes a pair and touches nothing, `storeKeypair` is the only thing that writes. The form holds the pair and writes it from `save()`.

Deliberately **not** a `store: boolean` on the existing call — a boolean that decides whether a secret is persisted fails silently in both directions. The split is in the type too: `VpnMintResult` has no `privateKeyRef` because there is nothing to point at yet.

Both handler bodies moved out of `index.ts` into `services/vpn/keys.ts`, which is what makes the property testable at the boundary that actually writes. The tests drive the real `vaultBridge` over a fake store rather than stubbing the write and asserting the stub went uncalled. Reinstating the old behaviour turns five of them red.

## The WireGuard tests can now outlive their own handshake budget

`tests/vpnWireguardDriver.test.ts` failed intermittently under a parallel suite, always as a bare `Test timed out in 15000ms`. Two previous investigations reached "undiagnosed", and the reason they did is the reason it kept happening.

vitest's `testTimeout` is 15 s. The file gives the driver **25 s** to see a first handshake — raised from 8 s precisely because two real devices sometimes need longer under load. That raise could never take effect. A slow handshake could not succeed, and could not fail usefully either: the driver's own error, the one naming the endpoint, UDP port and peer key (E22/E27), was not due for another ten seconds. Every occurrence destroyed its own evidence.

The live-sidecar tests now get 40 s, and a guard test asserts that ordering so it cannot invert again. It sits outside the `skipIf(!HAVE_NETD)` gate on purpose — it compares two constants, and a checkout without the sidecar built is exactly where someone edits a timeout.

Also here: a peer-harness `call()` that could never time out or notice its child dying, and a `freeUdpPort` race (observed once in ~80 runs) now retried rather than left to fail.

Two hypotheses are recorded as **disproved** in the commit message, since both looked obvious — the driver's fire-and-forget `close()` (measured at 0–24 ms under load average 180) and a deterministic UDP port collision (two sockets can share a port via `SO_REUSEADDR`, so it is not deterministic).

## Verification

1159 passing / 8 skipped, typecheck clean across node/web/cli, engine manifest verified. 84 consecutive runs of the WireGuard file clean under the load that previously produced two failures in about 170.

No change to the bundled engines, so the OpenVPN and OpenSSL versions and the corresponding source published beside them are unchanged from 0.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)