### PR TITLE
Release 0.6.2: retry every network step the release depends on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,5 @@ jobs:
       # quarter of an hour to every pull request, which is why the release
       # workflow is where that happens.
       - name: Engine build scripts parse
-        run: bash -n scripts/build-openvpn.sh scripts/fetch-wintun.sh scripts/build-frpc.sh scripts/build-sidecar.sh
+        run: bash -n scripts/lib/net-retry.sh scripts/build-openvpn.sh scripts/fetch-wintun.sh scripts/build-frpc.sh scripts/build-sidecar.sh
       - run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shellpilot",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shellpilot",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shellpilot",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Free, open-source SSH client, SFTP browser, SSH tunnel manager, multi-engine database GUI and encrypted secrets vault in one cross-platform desktop app. A MobaXterm, PuTTY and Termius alternative for Windows, macOS and Linux.",
   "keywords": [
     "ssh",

--- a/scripts/build-frpc.sh
+++ b/scripts/build-frpc.sh
@@ -71,6 +71,75 @@ build the dashboard assets. The API under /api and /healthz is unaffected.</p>
 HTML
 fi
 
+# Fetch what the build needs before anything compiles, retrying the network.
+#
+# A CI run of this script died mid-download with
+#
+#   github.com/fatedier/yamux@v0.0.0-...: read
+#   "https://proxy.golang.org/.../@v/....zip": stream error: INTERNAL_ERROR
+#
+# and passed unchanged on a re-run: proxy.golang.org dropped a stream. An
+# ordinary network flake, and it would not be worth much here except that the
+# release workflow runs this same script. A flake during a release is not a
+# re-run — it is a failed build across three runners, a tag to delete and
+# re-cut, and the draft releases from the half that succeeded to clean up.
+#
+# `go list -deps`, and not the two more obvious choices.
+#
+# Not `go build`, because a retry around a compile would run a genuine error
+# three times and then report it as a network problem — a worse failure than
+# the one being fixed. `go list` resolves and downloads without compiling, so
+# there is no compile error for it to mistake.
+#
+# Not `go mod download` either, which was the first thing tried here and is
+# wrong in a way worth recording: it resolves the whole module *graph*, so it
+# demands more than the build does. In this very repo it fails while the build
+# succeeds — frp's `gmsm` dependency requires `grpc@v1.31.0`, whose .mod file
+# `go mod download` insists on reading even though nothing in frpc imports
+# grpc. Prefetching with it would have enlarged the network surface this is
+# meant to shrink, and broken builds that work today from a warm cache.
+#
+# Run once per target because imports are build-constraint sensitive: a package
+# reached only under GOOS=windows is not in a linux resolution. Each pass after
+# the first is served from the module cache and costs nothing.
+#
+# Duplicated in build-sidecar.sh rather than sourced from a shared file, and
+# that is deliberate. The scripts in here are self-contained by convention —
+# three of them, no `source` between them, each re-deriving its own paths and
+# tool checks — and one function is not worth introducing the first sourcing
+# relationship in the tree along with the path-resolution failure it brings.
+# The case against duplication elsewhere in this repo was about a *rule* two
+# copies could disagree on; this is mechanism, and a drifting copy costs
+# nothing.
+prefetch_modules() {
+  local dir="$1"
+  local pkg="$2"
+  local t goos goarch nodedir attempt delay
+  for t in "${TARGETS[@]}"; do
+    read -r goos goarch nodedir <<<"$t"
+    attempt=1
+    delay=5
+    while :; do
+      # stdout is the package list and is not wanted; stderr is left alone, so
+      # the last attempt's real error is the one that reaches the log.
+      if ( cd "$dir" && CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+             go list -deps "$pkg" >/dev/null ); then
+        break
+      fi
+      if [ "$attempt" -ge 3 ]; then
+        echo "==> could not fetch modules for $goos/$goarch after 3 attempts" >&2
+        return 1
+      fi
+      echo "==> module fetch for $goos/$goarch failed (attempt $attempt of 3); retrying in ${delay}s" >&2
+      sleep "$delay"
+      attempt=$((attempt + 1))
+      delay=$((delay * 2))
+    done
+  done
+}
+
+prefetch_modules "$WORK/frp" ./cmd/frpc
+
 mkdir -p "$OUT_ROOT"
 
 for t in "${TARGETS[@]}"; do

--- a/scripts/build-frpc.sh
+++ b/scripts/build-frpc.sh
@@ -22,6 +22,10 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_ROOT="$ROOT/resources/bin"
 WORK="${FRP_WORKDIR:-$ROOT/.frp-build}"
 
+# Retries for every step below that reaches the network; see the file itself
+# for why these are shared rather than duplicated.
+. "$ROOT/scripts/lib/net-retry.sh"
+
 # GOOS/GOARCH on the left, Node's platform-arch on the right. The right-hand
 # names are what process.platform/process.arch produce and what
 # electron-builder's ${platform}-${arch} macro expands to, so the lookup path
@@ -41,10 +45,10 @@ command -v git >/dev/null 2>&1 || { echo "git not found" >&2; exit 1; }
 if [ ! -d "$WORK/frp/.git" ]; then
   echo "==> cloning frp $FRP_VERSION"
   mkdir -p "$WORK"
-  git clone --depth 1 --branch "$FRP_VERSION" "$FRP_REPO" "$WORK/frp"
+  retry_network "cloning frp" clone_pinned "$WORK/frp" "$FRP_REPO" "$FRP_VERSION"
 else
   echo "==> reusing $WORK/frp"
-  git -C "$WORK/frp" fetch --depth 1 origin "$FRP_VERSION"
+  retry_network "fetching frp $FRP_VERSION" git -C "$WORK/frp" fetch --depth 1 origin "$FRP_VERSION"
   git -C "$WORK/frp" checkout -q FETCH_HEAD
 fi
 
@@ -71,73 +75,7 @@ build the dashboard assets. The API under /api and /healthz is unaffected.</p>
 HTML
 fi
 
-# Fetch what the build needs before anything compiles, retrying the network.
-#
-# A CI run of this script died mid-download with
-#
-#   github.com/fatedier/yamux@v0.0.0-...: read
-#   "https://proxy.golang.org/.../@v/....zip": stream error: INTERNAL_ERROR
-#
-# and passed unchanged on a re-run: proxy.golang.org dropped a stream. An
-# ordinary network flake, and it would not be worth much here except that the
-# release workflow runs this same script. A flake during a release is not a
-# re-run — it is a failed build across three runners, a tag to delete and
-# re-cut, and the draft releases from the half that succeeded to clean up.
-#
-# `go list -deps`, and not the two more obvious choices.
-#
-# Not `go build`, because a retry around a compile would run a genuine error
-# three times and then report it as a network problem — a worse failure than
-# the one being fixed. `go list` resolves and downloads without compiling, so
-# there is no compile error for it to mistake.
-#
-# Not `go mod download` either, which was the first thing tried here and is
-# wrong in a way worth recording: it resolves the whole module *graph*, so it
-# demands more than the build does. In this very repo it fails while the build
-# succeeds — frp's `gmsm` dependency requires `grpc@v1.31.0`, whose .mod file
-# `go mod download` insists on reading even though nothing in frpc imports
-# grpc. Prefetching with it would have enlarged the network surface this is
-# meant to shrink, and broken builds that work today from a warm cache.
-#
-# Run once per target because imports are build-constraint sensitive: a package
-# reached only under GOOS=windows is not in a linux resolution. Each pass after
-# the first is served from the module cache and costs nothing.
-#
-# Duplicated in build-sidecar.sh rather than sourced from a shared file, and
-# that is deliberate. The scripts in here are self-contained by convention —
-# three of them, no `source` between them, each re-deriving its own paths and
-# tool checks — and one function is not worth introducing the first sourcing
-# relationship in the tree along with the path-resolution failure it brings.
-# The case against duplication elsewhere in this repo was about a *rule* two
-# copies could disagree on; this is mechanism, and a drifting copy costs
-# nothing.
-prefetch_modules() {
-  local dir="$1"
-  local pkg="$2"
-  local t goos goarch nodedir attempt delay
-  for t in "${TARGETS[@]}"; do
-    read -r goos goarch nodedir <<<"$t"
-    attempt=1
-    delay=5
-    while :; do
-      # stdout is the package list and is not wanted; stderr is left alone, so
-      # the last attempt's real error is the one that reaches the log.
-      if ( cd "$dir" && CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
-             go list -deps "$pkg" >/dev/null ); then
-        break
-      fi
-      if [ "$attempt" -ge 3 ]; then
-        echo "==> could not fetch modules for $goos/$goarch after 3 attempts" >&2
-        return 1
-      fi
-      echo "==> module fetch for $goos/$goarch failed (attempt $attempt of 3); retrying in ${delay}s" >&2
-      sleep "$delay"
-      attempt=$((attempt + 1))
-      delay=$((delay * 2))
-    done
-  done
-}
-
+# Everything the six builds below need, fetched once and retried.
 prefetch_modules "$WORK/frp" ./cmd/frpc
 
 mkdir -p "$OUT_ROOT"

--- a/scripts/build-openvpn.sh
+++ b/scripts/build-openvpn.sh
@@ -60,6 +60,10 @@ OPENSSL_URL="https://github.com/openssl/openssl/releases/download/openssl-${OPEN
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_ROOT="$ROOT/resources/bin"
 LIC_ROOT="$ROOT/resources/licenses/openvpn"
+
+# Retries for every step below that reaches the network; see the file itself
+# for why these are shared rather than duplicated.
+. "$ROOT/scripts/lib/net-retry.sh"
 WORK="${OPENVPN_WORKDIR:-$ROOT/.openvpn-build}"
 # Not under resources/: this is the GPL §3 corresponding source, a release
 # asset, and it has no business inside the installed app.
@@ -172,7 +176,7 @@ mkdir -p "$WORK" "$OUT_ROOT" "$LIC_ROOT" "$SRC_OUT"
 TARBALL="$WORK/openssl-${OPENSSL_VERSION}.tar.gz"
 if [ ! -f "$TARBALL" ]; then
   echo "==> fetching openssl ${OPENSSL_VERSION}"
-  curl -fsSL -o "$TARBALL.part" "$OPENSSL_URL"
+  retry_network "fetching openssl ${OPENSSL_VERSION}" curl -fsSL -o "$TARBALL.part" "$OPENSSL_URL"
   mv "$TARBALL.part" "$TARBALL"
 fi
 
@@ -249,10 +253,11 @@ fi
 SRC="$WORK/openvpn"
 if [ ! -d "$SRC/.git" ]; then
   echo "==> cloning openvpn $OPENVPN_TAG"
-  git clone --depth 1 --branch "$OPENVPN_TAG" "$OPENVPN_REPO" "$SRC"
+  retry_network "cloning openvpn" clone_pinned "$SRC" "$OPENVPN_REPO" "$OPENVPN_TAG"
 else
   echo "==> reusing $SRC"
-  git -C "$SRC" fetch --depth 1 origin "refs/tags/$OPENVPN_TAG:refs/tags/$OPENVPN_TAG" --force
+  retry_network "fetching openvpn $OPENVPN_TAG" \
+    git -C "$SRC" fetch --depth 1 origin "refs/tags/$OPENVPN_TAG:refs/tags/$OPENVPN_TAG" --force
   git -C "$SRC" checkout -q "refs/tags/$OPENVPN_TAG"
 fi
 

--- a/scripts/build-sidecar.sh
+++ b/scripts/build-sidecar.sh
@@ -19,6 +19,10 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SRC="$ROOT/sidecar/netd"
 OUT_ROOT="$ROOT/resources/bin"
 
+# Retries for every step below that reaches the network; see the file itself
+# for why these are shared rather than duplicated.
+. "$ROOT/scripts/lib/net-retry.sh"
+
 # The sidecar version tracks the app version: they are released together and a
 # mismatch between the two is a packaging bug, not a supported configuration.
 VERSION="${SHELLPILOT_NETD_VERSION:-$(node -p "require('$ROOT/package.json').version" 2>/dev/null || echo '0.0.0-dev')}"
@@ -62,75 +66,8 @@ command -v node >/dev/null 2>&1 || { echo "node not found (needed to merge the m
 echo "==> shellpilot-netd $VERSION ($BUILD_SHA)"
 echo "==> $(go version)"
 
-# Fetch what the build needs before anything compiles, retrying the network.
-#
-# A CI run of this script died mid-download with
-#
-#   github.com/fatedier/yamux@v0.0.0-...: read
-#   "https://proxy.golang.org/.../@v/....zip": stream error: INTERNAL_ERROR
-#
-# and passed unchanged on a re-run: proxy.golang.org dropped a stream. An
-# ordinary network flake, and it would not be worth much here except that the
-# release workflow runs this same script. A flake during a release is not a
-# re-run — it is a failed build across three runners, a tag to delete and
-# re-cut, and the draft releases from the half that succeeded to clean up.
-#
-# `go list -deps`, and not the two more obvious choices.
-#
-# Not `go build`, because a retry around a compile would run a genuine error
-# three times and then report it as a network problem — a worse failure than
-# the one being fixed. `go list` resolves and downloads without compiling, so
-# there is no compile error for it to mistake.
-#
-# Not `go mod download` either, which was the first thing tried here and is
-# wrong in a way worth recording: it resolves the whole module *graph*, so it
-# demands more than the build does. In this very repo it fails while the build
-# succeeds — frp's `gmsm` dependency requires `grpc@v1.31.0`, whose .mod file
-# `go mod download` insists on reading even though nothing in frpc imports
-# grpc. Prefetching with it would have enlarged the network surface this is
-# meant to shrink, and broken builds that work today from a warm cache.
-#
-# Run once per target because imports are build-constraint sensitive: a package
-# reached only under GOOS=windows is not in a linux resolution. Each pass after
-# the first is served from the module cache and costs nothing.
-#
-# Duplicated in build-frpc.sh rather than sourced from a shared file, and
-# that is deliberate. The scripts in here are self-contained by convention —
-# three of them, no `source` between them, each re-deriving its own paths and
-# tool checks — and one function is not worth introducing the first sourcing
-# relationship in the tree along with the path-resolution failure it brings.
-# The case against duplication elsewhere in this repo was about a *rule* two
-# copies could disagree on; this is mechanism, and a drifting copy costs
-# nothing.
-prefetch_modules() {
-  local dir="$1"
-  local pkg="$2"
-  local t goos goarch nodedir attempt delay
-  for t in "${TARGETS[@]}"; do
-    read -r goos goarch nodedir <<<"$t"
-    attempt=1
-    delay=5
-    while :; do
-      # stdout is the package list and is not wanted; stderr is left alone, so
-      # the last attempt's real error is the one that reaches the log.
-      if ( cd "$dir" && CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
-             go list -deps "$pkg" >/dev/null ); then
-        break
-      fi
-      if [ "$attempt" -ge 3 ]; then
-        echo "==> could not fetch modules for $goos/$goarch after 3 attempts" >&2
-        return 1
-      fi
-      echo "==> module fetch for $goos/$goarch failed (attempt $attempt of 3); retrying in ${delay}s" >&2
-      sleep "$delay"
-      attempt=$((attempt + 1))
-      delay=$((delay * 2))
-    done
-  done
-}
-
 # Before vet and test, not only before the build loop: those are the first
-# commands here that reach the network, so a flake would hit them first.
+# commands here that reach the network.
 prefetch_modules "$SRC" .
 
 # Fail the build rather than ship something that does not compile or whose

--- a/scripts/build-sidecar.sh
+++ b/scripts/build-sidecar.sh
@@ -62,6 +62,77 @@ command -v node >/dev/null 2>&1 || { echo "node not found (needed to merge the m
 echo "==> shellpilot-netd $VERSION ($BUILD_SHA)"
 echo "==> $(go version)"
 
+# Fetch what the build needs before anything compiles, retrying the network.
+#
+# A CI run of this script died mid-download with
+#
+#   github.com/fatedier/yamux@v0.0.0-...: read
+#   "https://proxy.golang.org/.../@v/....zip": stream error: INTERNAL_ERROR
+#
+# and passed unchanged on a re-run: proxy.golang.org dropped a stream. An
+# ordinary network flake, and it would not be worth much here except that the
+# release workflow runs this same script. A flake during a release is not a
+# re-run — it is a failed build across three runners, a tag to delete and
+# re-cut, and the draft releases from the half that succeeded to clean up.
+#
+# `go list -deps`, and not the two more obvious choices.
+#
+# Not `go build`, because a retry around a compile would run a genuine error
+# three times and then report it as a network problem — a worse failure than
+# the one being fixed. `go list` resolves and downloads without compiling, so
+# there is no compile error for it to mistake.
+#
+# Not `go mod download` either, which was the first thing tried here and is
+# wrong in a way worth recording: it resolves the whole module *graph*, so it
+# demands more than the build does. In this very repo it fails while the build
+# succeeds — frp's `gmsm` dependency requires `grpc@v1.31.0`, whose .mod file
+# `go mod download` insists on reading even though nothing in frpc imports
+# grpc. Prefetching with it would have enlarged the network surface this is
+# meant to shrink, and broken builds that work today from a warm cache.
+#
+# Run once per target because imports are build-constraint sensitive: a package
+# reached only under GOOS=windows is not in a linux resolution. Each pass after
+# the first is served from the module cache and costs nothing.
+#
+# Duplicated in build-frpc.sh rather than sourced from a shared file, and
+# that is deliberate. The scripts in here are self-contained by convention —
+# three of them, no `source` between them, each re-deriving its own paths and
+# tool checks — and one function is not worth introducing the first sourcing
+# relationship in the tree along with the path-resolution failure it brings.
+# The case against duplication elsewhere in this repo was about a *rule* two
+# copies could disagree on; this is mechanism, and a drifting copy costs
+# nothing.
+prefetch_modules() {
+  local dir="$1"
+  local pkg="$2"
+  local t goos goarch nodedir attempt delay
+  for t in "${TARGETS[@]}"; do
+    read -r goos goarch nodedir <<<"$t"
+    attempt=1
+    delay=5
+    while :; do
+      # stdout is the package list and is not wanted; stderr is left alone, so
+      # the last attempt's real error is the one that reaches the log.
+      if ( cd "$dir" && CGO_ENABLED=0 GOOS="$goos" GOARCH="$goarch" \
+             go list -deps "$pkg" >/dev/null ); then
+        break
+      fi
+      if [ "$attempt" -ge 3 ]; then
+        echo "==> could not fetch modules for $goos/$goarch after 3 attempts" >&2
+        return 1
+      fi
+      echo "==> module fetch for $goos/$goarch failed (attempt $attempt of 3); retrying in ${delay}s" >&2
+      sleep "$delay"
+      attempt=$((attempt + 1))
+      delay=$((delay * 2))
+    done
+  done
+}
+
+# Before vet and test, not only before the build loop: those are the first
+# commands here that reach the network, so a flake would hit them first.
+prefetch_modules "$SRC" .
+
 # Fail the build rather than ship something that does not compile or whose
 # tests are red. A tunnel sidecar that panics has the app's network stack in
 # its hands.

--- a/scripts/fetch-wintun.sh
+++ b/scripts/fetch-wintun.sh
@@ -40,6 +40,10 @@ WINTUN_SHA256="${WINTUN_SHA256:-07c256185d6ee3652e09fa55c0b673e2624b565e02c4b909
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT_ROOT="$ROOT/resources/bin"
 LIC_ROOT="$ROOT/resources/licenses/wintun"
+
+# Retries for every step below that reaches the network; see the file itself
+# for why these are shared rather than duplicated.
+. "$ROOT/scripts/lib/net-retry.sh"
 WORK="${WINTUN_WORKDIR:-$ROOT/.wintun-build}"
 
 # Left of the arrow is the directory inside the ZIP, right is Node's
@@ -66,7 +70,7 @@ mkdir -p "$WORK" "$LIC_ROOT"
 ZIP="$WORK/wintun-${WINTUN_VERSION}.zip"
 if [ ! -f "$ZIP" ]; then
   echo "==> fetching wintun ${WINTUN_VERSION}"
-  curl -fsSL -o "$ZIP.part" "$WINTUN_URL"
+  retry_network "fetching wintun ${WINTUN_VERSION}" curl -fsSL -o "$ZIP.part" "$WINTUN_URL"
   mv "$ZIP.part" "$ZIP"
 fi
 

--- a/scripts/lib/net-retry.sh
+++ b/scripts/lib/net-retry.sh
@@ -1,0 +1,126 @@
+# Network steps that a release cannot afford to lose to a dropped connection.
+#
+# Sourced by build-frpc.sh, build-sidecar.sh, build-openvpn.sh and
+# fetch-wintun.sh. Not executable on its own, and deliberately defines
+# functions and nothing else, so sourcing it has no side effects.
+#
+# WHY THIS EXISTS
+#
+# A CI run of build-frpc.sh died mid-download with
+#
+#   github.com/fatedier/yamux@v0.0.0-...: read
+#   "https://proxy.golang.org/.../@v/....zip": stream error: INTERNAL_ERROR
+#
+# and passed unchanged on a re-run. An ordinary network flake, and not worth
+# much on its own — except that the release workflow runs these same scripts. A
+# flake there is not a re-run: it is a failed build across three runners, a tag
+# to delete and re-cut, and the draft releases from the half that succeeded to
+# clean up first.
+#
+# Between them these four scripts clone two git repositories, fetch two tags,
+# and download two archives before anything is compiled. Every one of those is
+# the same bet on someone else's network staying up for the length of a
+# release.
+#
+# WHY A SHARED FILE, HAVING ARGUED AGAINST ONE
+#
+# The retry landed first in two scripts, duplicated, on the reasoning that the
+# scripts here are self-contained by convention and one small function did not
+# justify the first `source` in the tree. That reasoning does not survive the
+# real scope: four scripts need it, two of them need the clone wrapper as well,
+# and that is roughly sixty duplicated lines whose copies would drift. The
+# convention was worth keeping for one function and is not worth keeping for
+# six operations across four files.
+#
+# Every caller derives ROOT the same way, from BASH_SOURCE, so `.
+# "$ROOT/scripts/lib/net-retry.sh"` resolves wherever the script is run from.
+#
+# Written for bash 3.2, which is what macOS CI runs: no associative arrays, no
+# `${var,,}`, no `local -n`, and nothing that expands an empty array.
+
+# Run a command, and treat failure as possibly transient.
+#
+# Three attempts, backing off 5s then 10s. The output of the command is never
+# captured or silenced: on the final attempt the underlying error is the only
+# thing that explains what went wrong, and a retry that swallows what it
+# retried is untriageable.
+#
+#   retry_network "cloning frp" git clone --depth 1 ...
+#
+# The first argument is a human description used in the progress lines; the
+# rest is the command, run as-is. A shell function works here as well as a
+# binary, which is how the wrappers below are retried.
+retry_network() {
+  local what="$1"
+  shift
+  local attempt=1
+  local delay=5
+  while :; do
+    "$@" && return 0
+    if [ "$attempt" -ge 3 ]; then
+      echo "==> $what failed three times; giving up" >&2
+      return 1
+    fi
+    echo "==> $what failed (attempt $attempt of 3); retrying in ${delay}s" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
+# A shallow clone of one tag, safe to retry.
+#
+# The `rm -rf` is the whole point of the wrapper. A clone that dies partway
+# leaves the destination behind, and git refuses to clone into a directory that
+# is not empty — so a naive retry fails on the wreckage of the previous attempt
+# rather than on the network, and reports a confusing "already exists" instead
+# of the real error. Starting from nothing each time keeps every attempt
+# identical to the first.
+#
+# Only ever called with a destination this script owns and created under its
+# own work directory.
+clone_pinned() {
+  local dest="$1"
+  local repo="$2"
+  local ref="$3"
+  rm -rf "$dest"
+  git clone --depth 1 --branch "$ref" "$repo" "$dest"
+}
+
+# Fetch every module the build needs, before anything compiles.
+#
+# `go list -deps`, and not the two more obvious choices.
+#
+# Not `go build`: a retry around a compile would run a genuine error three
+# times and then report it as a network problem, which is a worse failure than
+# the one being fixed. `go list` resolves and downloads without compiling, so
+# there is no compile error for it to mistake for a flake.
+#
+# Not `go mod download` either, which was tried first and is wrong in a way
+# worth recording. It resolves the whole module *graph*, so it demands strictly
+# more than the build does: in this repo it fails outright while the build
+# succeeds, because frp's `gmsm` dependency requires `grpc@v1.31.0` and
+# `go mod download` insists on reading that .mod even though nothing in frpc
+# imports grpc. Prefetching with it would have enlarged the network surface
+# this is meant to shrink and broken builds that work today from a warm cache.
+#
+# Run once per target because imports are build-constraint sensitive: a package
+# reached only under GOOS=windows is not in a linux resolution. Every pass
+# after the first is served from the module cache and costs nothing.
+#
+# Reads the caller's TARGETS array, which both Go callers define in the same
+# "<goos> <goarch> <nodedir>" shape.
+_go_list_deps() {
+  ( cd "$1" && CGO_ENABLED=0 GOOS="$2" GOARCH="$3" go list -deps "$4" >/dev/null )
+}
+
+prefetch_modules() {
+  local dir="$1"
+  local pkg="$2"
+  local t goos goarch nodedir
+  for t in "${TARGETS[@]}"; do
+    read -r goos goarch nodedir <<<"$t"
+    retry_network "fetching modules for $goos/$goarch" \
+      _go_list_deps "$dir" "$goos" "$goarch" "$pkg" || return 1
+  done
+}


### PR DESCRIPTION
**Build resilience only.** Nothing in the shipped application changed — the binaries this produces behave exactly as 0.6.1's do. The benefit is to the releases *after* this one.

## Why

A CI run of `build-frpc.sh` died mid-download:

```
github.com/fatedier/yamux@v0.0.0-...: read
"https://proxy.golang.org/.../@v/....zip": stream error: INTERNAL_ERROR
```

and passed unchanged on a re-run. An ordinary network flake — except the release workflow runs these same scripts. A flake there is not a re-run: it is a failed build across three runners, a tag to delete and re-cut, and the draft releases from the half that succeeded to clean up. That already cost a full cycle during 0.6.0, for a different reason.

Between them these scripts clone two git repositories, fetch two tags and download two archives before anything compiles. All six now retry three times with 5s then 10s of backoff.

## The three non-obvious decisions

**`go list -deps`, not `go mod download`.** The obvious prefetch is wrong, and testing it is what showed that: `go mod download` resolves the whole module *graph*, so it demands strictly more than the build. In this repo it **fails while the build succeeds** — frp's `gmsm` dependency requires `grpc@v1.31.0`, whose `.mod` it insists on reading even though nothing in frpc imports grpc. It would have enlarged the network surface it was meant to shrink. `go list -deps` fetches exactly the build's import graph and does not compile, so there is no compile error for a retry to mistake for a flake.

**`clone_pinned` removes the destination before each attempt.** A clone that dies partway leaves the directory behind, git refuses to clone into a non-empty one, and a naive retry then fails on the wreckage of the previous attempt — reporting "already exists" instead of the real error.

**Shared file, reversing the previous commit's call.** Duplicating one function across two scripts to keep them self-contained was a fair trade; four scripts, six call sites and a clone wrapper is ~60 duplicated lines that would drift. The reversal is argued in the commit rather than applied quietly.

## Verified on bash 3.2 (what macOS CI runs)

Each script executed, not just parsed:

| script | happy path | failure path |
|---|---|---|
| `build-frpc.sh` | six-target build, exit 0 | clone retry: 3× on the real error, exit 1, zero "already exists" |
| `build-sidecar.sh` | six-target build, exit 0 | dead proxy: retries twice, gives up, never reaches the build loop |
| `fetch-wintun.sh` | real fetch + extract, exit 0 | unreachable URL: exit 1, no stray `.part` |
| `build-openvpn.sh` | full universal build through `retry_network`, exit 0, linkage check clean | — |

Plus 1159 passing / 8 skipped, typecheck clean, engine manifest verified.

`ci.yml`'s parse check now covers the new file, since `bash -n` on a caller does not look inside what it sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)