### PR TITLE
Rebuild opsmaxx.dev when a release is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -621,3 +621,35 @@ jobs:
               gh release edit "$TAG" --draft=false --latest
               ;;
           esac
+
+      # opsmaxx.dev bakes its download links in at build time by reading
+      # releases/latest, so the site has to rebuild before it offers this
+      # version. A daily job on that repo is the safety net; this makes it
+      # immediate.
+      #
+      # Prereleases are skipped, because releases/latest ignores them and the
+      # rebuild would produce a byte-identical site. The dash test is the same
+      # one the publish step above uses to pick the update channel: the tag is
+      # "v" plus the package.json version, so the only dash it can contain is
+      # the semver prerelease separator.
+      #
+      # Never fails the run: the release is already public by this point, and
+      # a red cross on a shipped release would be misleading when the worst
+      # case is a landing page that is a few hours stale.
+      - name: Rebuild opsmaxx.dev
+        if: ${{ !contains(github.ref_name, '-') }}
+        continue-on-error: true
+        env:
+          HOOK: ${{ secrets.CF_PAGES_DEPLOY_HOOK }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if [ -z "$HOOK" ]; then
+            echo "::warning::CF_PAGES_DEPLOY_HOOK is not set. opsmaxx.dev will pick $TAG up on its next scheduled rebuild."
+            exit 0
+          fi
+
+          if curl -fsS --retry 3 --retry-delay 5 -X POST "$HOOK" -o /dev/null; then
+            echo "Asked Cloudflare Pages to rebuild opsmaxx.dev for $TAG."
+          else
+            echo "::warning::Could not reach the Cloudflare Pages deploy hook. opsmaxx.dev will pick $TAG up on its next scheduled rebuild."
+          fi

--- a/src/renderer/src/components/ai/CliPairingBanner.tsx
+++ b/src/renderer/src/components/ai/CliPairingBanner.tsx
@@ -51,7 +51,7 @@ export function CliPairingBanner(): React.JSX.Element | null {
             {request.code}
           </div>
           <div className="s-desc" style={{ marginTop: 6 }}>
-            Expires in {secondsLeft}s. If you did not run a OpsMaxx CLI command, click Cancel.
+            Expires in {secondsLeft}s. If you did not run an OpsMaxx CLI command, click Cancel.
           </div>
         </div>
       </div>

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -123,7 +123,7 @@ const SETTING_INDEX: SettingEntry[] = [
   {
     section: 'general',
     title: 'Check for updates automatically',
-    desc: 'Look for a newer ShellPilot on a schedule.',
+    desc: 'Look for a newer OpsMaxx on a schedule.',
     aliases: 'auto update upgrade version release'
   },
   {
@@ -135,11 +135,11 @@ const SETTING_INDEX: SettingEntry[] = [
   { section: 'general', title: 'Install on quit', desc: 'Apply a downloaded update when you quit.', aliases: 'update upgrade restart' },
   { section: 'general', title: 'Channel', desc: 'Which release channel updates come from.', aliases: 'beta stable release channel update' },
   // Appearance
-  { section: 'appearance', title: 'Theme', desc: 'Dark is the primary ShellPilot experience.', aliases: 'dark light system colour color' },
+  { section: 'appearance', title: 'Theme', desc: 'Dark is the primary OpsMaxx experience.', aliases: 'dark light system colour color' },
   {
     section: 'appearance',
     title: 'Start when I log in',
-    desc: 'Launch ShellPilot with your machine, so background checking and alerts run from login.',
+    desc: 'Launch OpsMaxx with your machine, so background checking and alerts run from login.',
     aliases: 'autostart auto start login item startup boot'
   },
   {
@@ -151,7 +151,7 @@ const SETTING_INDEX: SettingEntry[] = [
   {
     section: 'appearance',
     title: 'Allow adding and revoking keys on servers',
-    desc: 'Whether ShellPilot may write authorized_keys on your machines.',
+    desc: 'Whether OpsMaxx may write authorized_keys on your machines.',
     aliases: 'access write authorized keys revoke'
   },
   {
@@ -285,7 +285,7 @@ function SettingSwitch({
  * Starting with the machine.
  *
  * This pairs with background checking rather than being a cosmetic preference:
- * the fleet poll runs from the app root, so a OpsMaxx that starts at login
+ * the fleet poll runs from the app root, so an OpsMaxx that starts at login
  * is a fleet watched from login. Without it, "background checking" only means
  * background of whenever somebody last opened the app.
  *

--- a/src/renderer/src/components/settings/ShortcutManager.tsx
+++ b/src/renderer/src/components/settings/ShortcutManager.tsx
@@ -64,7 +64,7 @@ export function ShortcutManager(): React.JSX.Element {
     if (!raw) return
     const parsed = parseShortcutFile(raw)
     if (!parsed) {
-      return toast('That file is not a OpsMaxx shortcut export.', 'error', {
+      return toast('That file is not an OpsMaxx shortcut export.', 'error', {
         label: 'Choose another file',
         run: () => void importJson()
       })


### PR DESCRIPTION
## What

Adds a final step to the `release` job that pings a Cloudflare Pages deploy hook once the release is public, so opsmaxx.dev picks up the new installers immediately.

The landing page reads `releases/latest` **at build time** so its download buttons link straight at the installers, with real filenames and sizes. Without this the site is stale from the moment a release ships until its next build.

## Details

- **Prereleases are skipped.** `releases/latest` ignores them, so the rebuild would produce a byte-identical site. The dash test is the same one the publish step above uses to choose the update channel.
- **It never fails the run.** The release is already public by the time this executes, and a red cross on a shipped release would be misleading. If the hook is unset or unreachable it emits a warning; opsmaxx.dev has its own daily rebuild as the safety net.

## Before this works

Set `CF_PAGES_DEPLOY_HOOK` on this repository:

1. Cloudflare Pages → the opsmaxx.dev project → Settings → Builds & deployments → Deploy hooks → create one
2. Save the URL as the `CF_PAGES_DEPLOY_HOOK` secret here

Until then the step logs a warning and exits cleanly.

## Also in this branch

A separate commit finishes the OpsMaxx rename in strings people actually read: four settings descriptions still said OpsMaxx, and two toasts read "a OpsMaxx" after an earlier pass renamed around the article.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
