### PR TITLE
Link opsmaxx.dev, and add the package-manager install routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Your DevOps workstation, everywhere. Windows · macOS · Linux.
 
+**[opsmaxx.dev](https://opsmaxx.dev)**
+
 <a href="https://github.com/OpsMaxx/ShellPilot/releases/latest">
 <img src="https://img.shields.io/badge/Download%20OpsMaxx-22c7d6?style=for-the-badge&labelColor=0d1119" alt="Download OpsMaxx" height="34" />
 </a>
@@ -21,7 +23,7 @@ Your DevOps workstation, everywhere. Windows · macOS · Linux.
 [![Stars](https://img.shields.io/github/stars/OpsMaxx/ShellPilot?style=flat-square&label=stars&color=22c7d6&labelColor=30363d)](https://github.com/OpsMaxx/ShellPilot/stargazers)
 [![License](https://img.shields.io/badge/license-MIT-22c7d6?style=flat-square&labelColor=30363d)](LICENSE)
 
-[Features](#features) · [AI Agent Access](#ai-agent-access) · [Install](#install) · [Quick start](#quick-start) · [Comparison](#opsmaxx-vs-mobaxterm-putty-termius-and-securecrt) · [Workspaces](#workspaces) · [Local terminal](#local-terminal) · [Command palette](#command-palette) · [Shortcuts](#keyboard-shortcuts) · [Databases](#databases) · [Vault](#vault) · [Use cases](#real-world-use-cases) · [FAQ](#faq) · [Contributing](#contributing) · [Licence](#licence)
+[Website](https://opsmaxx.dev) · [Features](#features) · [AI Agent Access](#ai-agent-access) · [Install](#install) · [Quick start](#quick-start) · [Comparison](#opsmaxx-vs-mobaxterm-putty-termius-and-securecrt) · [Workspaces](#workspaces) · [Local terminal](#local-terminal) · [Command palette](#command-palette) · [Shortcuts](#keyboard-shortcuts) · [Databases](#databases) · [Vault](#vault) · [Use cases](#real-world-use-cases) · [FAQ](#faq) · [Contributing](#contributing) · [Licence](#licence)
 
 </div>
 
@@ -263,7 +265,27 @@ account-level Connectors feature with nowhere to put a bearer token for a `127.0
 
 OpsMaxx ships a stdio bridge for exactly this case — a pure protocol relay that forwards
 messages to the same authenticated HTTP endpoint, so a stdio-only client gets the identical
-policy, approval and audit path (`src/cli/bridge.ts`). Point Desktop at it:
+policy, approval and audit path (`src/cli/bridge.ts`).
+
+The short way is the npm package, which is the same relay without the absolute paths:
+
+```json
+{
+  "mcpServers": {
+    "opsmaxx": {
+      "command": "npx",
+      "args": ["-y", "@opsmaxx/mcp"],
+      "env": { "OPSMAXX_MCP_TOKEN": "<token>", "OPSMAXX_MCP_PORT": "<port>" }
+    }
+  }
+}
+```
+
+If you have run `opsmaxx claude` at least once, the `env` block can be dropped: the package
+reads the session the CLI already cached. Source and detail:
+[`@opsmaxx/mcp`](https://github.com/OpsMaxx/opsmaxx-mcp).
+
+Or point Desktop straight at the bundled bridge, with no Node dependency at all:
 
 ```json
 {
@@ -331,6 +353,19 @@ Download the latest build from the [Releases](https://github.com/OpsMaxx/ShellPi
 | **macOS (Intel)** | [`OpsMaxx-x.y.z-x64.dmg`](https://github.com/OpsMaxx/ShellPilot/releases/latest) | Intel Macs |
 | **Linux** | [`OpsMaxx-x.y.z-x86_64.AppImage`](https://github.com/OpsMaxx/ShellPilot/releases/latest) | `chmod +x OpsMaxx-*.AppImage` and run — works on any distribution |
 | **Linux (Debian / Ubuntu)** | [`OpsMaxx-x.y.z-amd64.deb`](https://github.com/OpsMaxx/ShellPilot/releases/latest) | `sudo apt install ./OpsMaxx-*-amd64.deb` |
+
+### Package managers
+
+| | |
+|---|---|
+| **macOS** | `brew trust opsmaxx/tap` then `brew install --cask opsmaxx/tap/opsmaxx` |
+| **Windows** | `winget install OpsMaxx.OpsMaxx` — [pending review](https://github.com/microsoft/winget-pkgs/pull/431465) |
+
+Homebrew's main cask repository has a notability threshold OpsMaxx does not meet yet, so
+the cask lives in [its own tap](https://github.com/OpsMaxx/homebrew-tap) for now. The
+`brew trust` step is Homebrew refusing to load a third-party tap until you say you trust
+it; the cask it guards is a few lines of metadata you can read first. Homebrew clears the
+quarantine flag on install, so this route also sidesteps the first-run warning below.
 
 <details>
 <summary><b>What are the other files on the release page?</b></summary>

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,26 @@
+# winget manifests
+
+What was submitted to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)
+for `OpsMaxx.OpsMaxx`, kept here so the next version is a diff rather than a rewrite.
+
+- `InstallerType: nullsoft` — winget's name for the NSIS installer electron-builder
+  produces. It is not `nsis`; the schema rejects that.
+- `Scope: user` — `nsis.perMachine` is `false` in `electron-builder.yml`.
+- `ReleaseDate` is quoted, or a YAML parser hands the schema a date object where it
+  wants a string.
+- `InstallerSha256` must match the published file. Take it from the release notes'
+  checksum table and verify it against the download before submitting.
+
+Validate before opening a PR. On Windows:
+
+```powershell
+winget validate --manifest manifests/o/OpsMaxx/OpsMaxx/<version>
+```
+
+Anywhere else, against the published schemas:
+
+```bash
+pip install jsonschema pyyaml
+# manifest.version / manifest.installer / manifest.defaultLocale, v1.6.0
+# https://raw.githubusercontent.com/microsoft/winget-cli/master/schemas/JSON/manifests/v1.6.0/
+```

--- a/packaging/winget/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.installer.yaml
+++ b/packaging/winget/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+PackageIdentifier: OpsMaxx.OpsMaxx
+PackageVersion: 0.28.2
+InstallerType: nullsoft
+Scope: user
+InstallModes:
+  - interactive
+  - silent
+  - silentWithProgress
+UpgradeBehavior: install
+ReleaseDate: "2026-09-08"
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/OpsMaxx/ShellPilot/releases/download/v0.28.2/OpsMaxx-0.28.2-setup.exe
+    InstallerSha256: B59013A378F0C2FE7CE75CE8A4D048AD54A2A2F84EA536D1E2EAB926335F0515
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/packaging/winget/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.locale.en-US.yaml
+++ b/packaging/winget/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.locale.en-US.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+PackageIdentifier: OpsMaxx.OpsMaxx
+PackageVersion: 0.28.2
+PackageLocale: en-US
+Publisher: OpsMaxx
+PublisherUrl: https://opsmaxx.dev/
+PublisherSupportUrl: https://github.com/OpsMaxx/ShellPilot/issues
+PackageName: OpsMaxx
+PackageUrl: https://opsmaxx.dev/
+License: MIT
+LicenseUrl: https://github.com/OpsMaxx/ShellPilot/blob/main/LICENSE
+Copyright: Copyright (c) OpsMaxx
+ShortDescription: SSH client, SFTP browser, database manager, secrets vault and MCP gateway for AI agents.
+Description: |-
+  OpsMaxx is a free, open-source desktop application that keeps an SSH terminal, an SFTP
+  browser, five database engines, SSH tunnels and VPN, an encrypted secrets vault and fleet
+  operations in one window, all sharing a single credential store.
+
+  It also exposes a policy-scoped MCP bridge, so Claude Code, Codex, Gemini CLI and other
+  MCP clients can operate servers by friendly name without ever receiving an SSH password,
+  a private key, a database credential or a hostname. Every capability is ALLOW, ASK or DENY
+  per access group, sensitive actions wait for approval, and every action is written to an
+  audit log.
+Moniker: opsmaxx
+Tags:
+  - ssh
+  - ssh-client
+  - sftp
+  - terminal
+  - database
+  - devops
+  - mcp
+  - vault
+  - tunnel
+  - vpn
+ReleaseNotesUrl: https://github.com/OpsMaxx/ShellPilot/releases/tag/v0.28.2
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/packaging/winget/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.yaml
+++ b/packaging/winget/manifests/o/OpsMaxx/OpsMaxx/0.28.2/OpsMaxx.OpsMaxx.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+PackageIdentifier: OpsMaxx.OpsMaxx
+PackageVersion: 0.28.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
## Why

The README never mentioned opsmaxx.dev. The repo is the project's most visible page, so that cost a link for readers and a ranking signal for the site — the site's own content could not outrank a page that did not point at it.

## What changed

**The website is linked** — under the tagline, and first in the nav row.

**A "Package managers" section** under Install:

| | |
|---|---|
| macOS | `brew trust opsmaxx/tap` then `brew install --cask opsmaxx/tap/opsmaxx` |
| Windows | `winget install OpsMaxx.OpsMaxx` — [in review](https://github.com/microsoft/winget-pkgs/pull/431465) |

The cask lives in [OpsMaxx/homebrew-tap](https://github.com/OpsMaxx/homebrew-tap) rather than homebrew-cask, which applies a notability threshold this project does not meet yet. Both installer hashes are pinned from the release notes, and I verified the Windows one by downloading the file and hashing it rather than trusting the table.

`brew trust` is not optional — Homebrew refuses to load casks from an untrusted third-party tap — so it is stated rather than left to be discovered as an error.

**Claude Desktop** gains the npm form of the existing stdio bridge, above the bundle-path form:

```json
"command": "npx", "args": ["-y", "@opsmaxx/mcp"]
```

Same relay, no absolute paths, and no `env` block at all once `opsmaxx claude` has cached a session. Source: [OpsMaxx/opsmaxx-mcp](https://github.com/OpsMaxx/opsmaxx-mcp).

## Note

`@opsmaxx/mcp` is written and tested but **not yet published to npm** — that needs an interactive `npm login`. The README references it, so publish before merging, or I can drop that block and add it back after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)