### PR TITLE
Write down which surfaces a release touches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# Working on OpsMaxx
+
+The app was renamed from ShellPilot to OpsMaxx. The **GitHub repo slug is still
+`OpsMaxx/ShellPilot`** and changing it would break every existing download link, so
+`ShellPilot` in a URL is correct and `ShellPilot` in user-facing text is not.
+
+## Release surfaces
+
+Shipping a version touches more than this repo. Pushing a `v*` tag starts it:
+
+| Surface | Where | Automated? |
+|---|---|---|
+| Installers, scans, notes | `.github/workflows/release.yml` | **Yes** — on tag push |
+| opsmaxx.dev download links | `OpsMaxx/opsmaxx.dev` | **Yes** — deploy hook, then daily cron |
+| Homebrew cask | `OpsMaxx/homebrew-tap` | **Yes** — daily, reads the release notes |
+| winget manifest | `packaging/winget/` here | **No** — hand-written PR each version |
+| `@opsmaxx/mcp` on npm | `OpsMaxx/opsmaxx-mcp` | **No** — but only when the bridge changes |
+| MCP registry entry | `OpsMaxx/opsmaxx-mcp` `server.json` | **No** — follows an npm publish |
+
+So a routine release is: **tag, then open the winget PR.** Everything else lands on its own.
+
+### What the release workflow does
+
+Builds all three platforms, scans (ClamAV over every artifact, Defender on the Windows
+installer, VirusTotal on `.exe` and `.dmg` **only** — Linux artifacts are not
+VirusTotal-scanned, so do not claim they are), publishes the notes with a SHA-256 table,
+then pings the Cloudflare Pages deploy hook.
+
+That last step is skipped for prereleases, and it never fails the run — the release is
+already public by then, and the site has a daily rebuild as a backstop. It needs the
+`CF_PAGES_DEPLOY_HOOK` secret on this repo.
+
+### The site reads releases at build time
+
+`opsmaxx.dev/src/lib/releases.ts` resolves the latest release **when the site builds**, so
+the site has to rebuild for a new version to appear. Three layers: the GitHub API, then a
+no-API path (`/releases/latest` redirects to the tag, asset names follow
+electron-builder's scheme, a `HEAD` gives each size), then the releases page. The
+unauthenticated API allows 60 requests/hour per IP and Cloudflare's builders share IPs, so
+layer 2 exists because layer 1 genuinely failed in production. Setting `GITHUB_TOKEN` in
+the Pages environment makes layer 1 reliable. The chosen layer is printed in the build log.
+
+The site is deployed as an **assets-only Worker**, not classic Pages: `wrangler.jsonc`
+declares `assets.directory` and `not_found_handling: "404-page"`. Without that file
+`wrangler deploy` tries an interactive `astro add cloudflare` and every deploy fails while
+the build still reports success — check the Cloudflare dashboard, not just `git push`.
+
+## Traps that have already cost time
+
+- **`tests/releaseWorkflow.test.ts` ratchets the release job.** Every inline `run` step
+  must be listed in `CEILING` with a line limit. Adding a step without registering it
+  turns `main` red.
+- **winget calls NSIS `nullsoft`**, not `nsis`. `ReleaseDate` must be quoted or a YAML
+  parser hands the schema a date object. `Scope: user`, because `nsis.perMachine` is
+  `false`. Validate against the published v1.6.0 JSON schemas before opening a PR.
+- **Homebrew's main cask repo has a notability threshold** (~75 stars) this project does
+  not meet, hence the own tap. Third-party taps also need `brew trust` before they load —
+  say so in any install instructions.
+- **The MCP registry is case-sensitive**: the namespace is `io.github.OpsMaxx`, matching
+  the org's exact login. `mcpName` in the npm package must equal the server name exactly,
+  and it lives inside the tarball, so fixing it needs a version bump. Descriptions are
+  capped at 100 characters.
+- **`mcp-publisher login github` (device flow) only grants your personal namespace.** Org
+  namespaces need `read:org`, which that flow does not request. Use
+  `mcp-publisher login github --token "$(gh auth token)"`.
+
+## Claims about the product
+
+This repo is public and the audience checks things. Two claims that were wrong on the site
+and had to be corrected: "sudo is refused" (only escalation *shells* — `sudo -i`, `su`,
+`sudo bash` — are refused; `sudo -n` is used for privileged reads and is on by default),
+and "every release is scanned by 70+ engines" (VirusTotal covers `.exe` and `.dmg` only).
+
+Verify against `src/`, not the README, before repeating a security claim.


### PR DESCRIPTION
## Why

Shipping a version updates six things across four repositories, and only four of them are automated. That knowledge was carried in one person's head — which is how both the winget manifest and the Homebrew cask went stale within hours of being created, and how a deploy-hook step landed without being registered with the ratchet and turned `main` red.

## What it records

**What a tag actually sets off**, and which surfaces move on their own:

| Surface | Automated? |
|---|---|
| Installers, scans, notes | Yes — on tag push |
| opsmaxx.dev download links | Yes — deploy hook, then daily cron |
| Homebrew cask | Yes — daily, from the notes' checksum table |
| winget manifest | **No** — hand-written PR per version |
| `@opsmaxx/mcp` + MCP registry | **No** — only when the bridge changes |

So a routine release is: tag, then open the winget PR.

**The traps, each already paid for once:** the release-job ratchet in `tests/releaseWorkflow.test.ts`; winget calling NSIS `nullsoft` and needing a quoted `ReleaseDate`; Homebrew's notability threshold and the `brew trust` step; the MCP registry's case-sensitive `io.github.OpsMaxx` namespace and 100-character description cap; and `mcp-publisher`'s device flow not granting org namespaces without `read:org`.

**Why the site has a three-layer release resolver** — the unauthenticated GitHub API failed on Cloudflare's shared build IPs in production, which silently degraded every download button to "go to the releases page".

**Two claims that were published and wrong**, both repeated from the README rather than checked against `src/`: that sudo is refused outright (only escalation *shells* are; `sudo -n` is used for privileged reads and is on by default), and that every release is scanned by 70+ engines (VirusTotal covers `.exe` and `.dmg` only).

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)