### PR TITLE
Fix the flaky supervisor teardown, and three tests that meant "not built yet"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,15 @@ declares `assets.directory` and `not_found_handling: "404-page"`. Without that f
 `wrangler deploy` tries an interactive `astro add cloudflare` and every deploy fails while
 the build still reports success — check the Cloudflare dashboard, not just `git push`.
 
+## Running the tests
+
+`npm run build` first, or three integration tests skip: `cliPairing` and
+`connectAgent` spawn `out/cli/index.js` as a real MCP server, and it is a build
+artifact. CI builds before it tests, so they only skip locally, and they say so
+when they do. A fresh git worktree also has no `node_modules` of its own —
+dependencies live at the main checkout — so anything resolving a package should
+ask the resolver rather than assume a relative path.
+
 ## Traps that have already cost time
 
 - **`tests/releaseWorkflow.test.ts` ratchets the release job.** Every inline `run` step

--- a/tests/cliPairing.integration.test.ts
+++ b/tests/cliPairing.integration.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { join } from 'node:path'
+import { hasBuiltCli, warnIfUnbuilt } from './fixtures/builtCli'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 
@@ -42,6 +43,8 @@ async function postJson(path: string, body: unknown): Promise<Record<string, unk
   return (await res.json()) as Record<string, unknown>
 }
 
+warnIfUnbuilt()
+
 describe('CLI pairing (integration)', () => {
   beforeAll(async () => {
     resetMcpAuthForTests()
@@ -70,7 +73,7 @@ describe('CLI pairing (integration)', () => {
     expect(codes[0]).toMatch(/^\d{6}$/)
   })
 
-  it('rejects the wrong code, then accepts the right one and hands back a working token', async () => {
+  it.skipIf(!hasBuiltCli)('rejects the wrong code, then accepts the right one and hands back a working token', async () => {
     let code = ''
     const off = onCliPairingEvent((e: CliPairingEvent) => {
       if (e.type === 'created') code = e.request.code

--- a/tests/connectAgent.integration.test.ts
+++ b/tests/connectAgent.integration.test.ts
@@ -5,6 +5,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { mkdtempSync, rmSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { hasBuiltCli, warnIfUnbuilt } from './fixtures/builtCli'
 
 import { refreshMcpDataCache, listCachedWorkspaces } from '../src/main/services/mcpDataCache'
 import { setAssignment, listAssignments, listGroups, resetPolicyCacheForTests } from '../src/main/services/policyStore'
@@ -93,6 +94,8 @@ async function callText(client: Client, name: string): Promise<string> {
   return res.content.map((c) => c.text).join('\n')
 }
 
+warnIfUnbuilt()
+
 describe('connect flow', () => {
   it('a session created without any assignment cannot see a server', async () => {
     // The pre-button state: policy seeded, assignments empty. This is the
@@ -153,7 +156,7 @@ describe('connect flow', () => {
     }
   })
 
-  it('the Codex config it writes is a usable MCP server', async () => {
+  it.skipIf(!hasBuiltCli)('the Codex config it writes is a usable MCP server', async () => {
     const file = join(dir, 'config.toml')
     const token = newSession('Codex', 'grp-read-only', 'Read Only')
     expect(writeCodexConfigTo(file, token, PORT).ok).toBe(true)
@@ -178,7 +181,7 @@ describe('connect flow', () => {
     }
   })
 
-  it('the Claude Desktop config it writes is a usable MCP server', async () => {
+  it.skipIf(!hasBuiltCli)('the Claude Desktop config it writes is a usable MCP server', async () => {
     const file = join(dir, 'claude_desktop_config.json')
     const token = newSession('Claude Desktop', 'grp-read-only', 'Read Only')
     const result = writeClaudeDesktopConfigTo(file, token, PORT)

--- a/tests/fixtures/builtCli.ts
+++ b/tests/fixtures/builtCli.ts
@@ -1,0 +1,29 @@
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+/**
+ * The built CLI entry that the integration tests spawn as a real MCP server.
+ *
+ * It is a build artifact, not source: `npm run build` produces it, and CI runs
+ * that before `npm run test`. A fresh checkout or a git worktree has no `out/`,
+ * so the spawn succeeds, the child exits immediately, and the MCP client
+ * reports `Connection closed` — which reads like the config writer is broken
+ * when nothing is wrong with it at all.
+ *
+ * Tests that need it should skip on `hasBuiltCli` rather than fail, and say so.
+ */
+export const BUILT_CLI = fileURLToPath(new URL('../../out/cli/index.js', import.meta.url))
+
+export const hasBuiltCli = existsSync(BUILT_CLI)
+
+/**
+ * Says why, once per file, so a skipped integration test is never silent — a
+ * quiet skip is how a suite ends up green while proving nothing.
+ */
+export function warnIfUnbuilt(): void {
+  if (hasBuiltCli) return
+  console.warn(
+    `[integration] skipping tests that spawn the built CLI: ${BUILT_CLI} does not exist. ` +
+      'Run `npm run build` first; CI does this before `npm run test`.'
+  )
+}

--- a/tests/fixtures/rmTemp.ts
+++ b/tests/fixtures/rmTemp.ts
@@ -1,0 +1,35 @@
+import { rmSync } from 'node:fs'
+
+/**
+ * Remove a test's temp root, tolerating a directory that is still being
+ * written to.
+ *
+ * The supervisor writes `<runId>.pid` under its runRoot when it spawns and
+ * unlinks it when a run goes terminal, and does both fire-and-forget —
+ * `void unlink(...)` in `goTerminal`, a `.catch()`-swallowed `writeFile` in
+ * `writePidRecord`. Neither is awaitable from a test, so a write can still be
+ * in flight when teardown runs. `fs.promises` work executes on libuv's
+ * threadpool, so it proceeds *in parallel* with a synchronous `rmSync` on the
+ * main thread: the walk empties a directory, a queued write puts a file back,
+ * and the `rmdir` fails ENOTEMPTY.
+ *
+ * `force: true` does not cover this — it suppresses missing paths, not
+ * repopulated ones. Neither does `maxRetries`, which is the tempting fix and
+ * measurably useless here: `rmSync` is synchronous, so its internal retries
+ * cannot yield to let the pending writes finish. Measured over 40 attempts
+ * with four writes in flight: `maxRetries: 5` failed 20 times, the loop below
+ * failed none. The `await` is the entire difference.
+ */
+export async function rmTemp(root: string, attempts = 10): Promise<void> {
+  for (let i = 0; ; i++) {
+    try {
+      rmSync(root, { recursive: true, force: true })
+      return
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code
+      if (i >= attempts - 1 || code !== 'ENOTEMPTY') throw err
+      // Yields, so the queued threadpool writes can land before the next try.
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    }
+  }
+}

--- a/tests/localPtySmoke.test.ts
+++ b/tests/localPtySmoke.test.ts
@@ -88,7 +88,15 @@ describe('@lydell/node-pty spawns a real shell', () => {
   it('still ships the flow-control options localPty relies on', async () => {
     await loadPty()
     const { readdir, readFile } = await import('node:fs/promises')
-    const scope = new URL('../node_modules/@lydell/', import.meta.url)
+    const { createRequire } = await import('node:module')
+    const { pathToFileURL } = await import('node:url')
+    // Ask the resolver where the package actually is rather than assuming a
+    // `node_modules` next to this file. In a git worktree there isn't one —
+    // dependencies are installed once at the main checkout — so the hardcoded
+    // path made this fail with ENOENT on every worktree branch, which reads
+    // like a broken dependency rather than a test looking in the wrong place.
+    const entry = pathToFileURL(createRequire(import.meta.url).resolve('@lydell/node-pty'))
+    const scope = new URL('../', entry)
     const siblings = (await readdir(scope)).filter((n) => n.startsWith('node-pty-'))
     expect(siblings.length).toBeGreaterThan(0)
 

--- a/tests/processService.test.ts
+++ b/tests/processService.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { EventEmitter } from 'node:events'
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { rmTemp } from './fixtures/rmTemp'
 import { PassThrough } from 'node:stream'
 import type { ChildProcess } from 'node:child_process'
 import {
@@ -189,9 +190,9 @@ beforeEach(() => {
     toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date']
   })
 })
-afterEach(() => {
+afterEach(async () => {
   vi.useRealTimers()
-  rmSync(root, { recursive: true, force: true })
+  await rmTemp(root)
 })
 
 describe('the list survives a restart of the app', () => {

--- a/tests/vpnReap.test.ts
+++ b/tests/vpnReap.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { rmTemp } from './fixtures/rmTemp'
 import { Supervisor, identityMatches, parseDarwinPs, parseWindowsProcess } from '../src/main/services/vpn/supervisor'
 import type { VpnPidRecord } from '../src/main/services/vpn/supervisor'
 
@@ -69,7 +70,9 @@ beforeEach(() => {
   alive = new Set()
   probes = []
 })
-afterEach(() => rmSync(root, { recursive: true, force: true }))
+afterEach(async () => {
+  await rmTemp(root)
+})
 
 describe('orphan reaping', () => {
   it('deletes the record of a pid that is gone without signalling anything', async () => {

--- a/tests/vpnSupervisor.test.ts
+++ b/tests/vpnSupervisor.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { EventEmitter } from 'node:events'
 import { createHash } from 'node:crypto'
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { rmTemp } from './fixtures/rmTemp'
 import { PassThrough } from 'node:stream'
 import { fileURLToPath } from 'node:url'
 import type { ChildProcess, SpawnOptions } from 'node:child_process'
@@ -112,9 +113,9 @@ function baseSpec(over: Partial<SupervisedSpec> = {}): SupervisedSpec {
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), 'sp-sup-'))
 })
-afterEach(() => {
+afterEach(async () => {
   vi.useRealTimers()
-  rmSync(root, { recursive: true, force: true })
+  await rmTemp(root)
 })
 
 describe('backoff', () => {
@@ -767,8 +768,8 @@ describe('a second, non-VPN consumer', () => {
       expect(killed).toEqual([])
       expect(existsSync(join(vpnRoot, 'tunnel-1.pid'))).toBe(true)
     } finally {
-      rmSync(vpnRoot, { recursive: true, force: true })
-      rmSync(procRoot, { recursive: true, force: true })
+      await rmTemp(vpnRoot)
+      await rmTemp(procRoot)
     }
   })
 })


### PR DESCRIPTION
Two unrelated causes of red builds, both of which report something other than what is wrong.

## 1. The flake: a temp directory still being written to

`tests/vpnSupervisor.test.ts` fails intermittently with `ENOTEMPTY` from the `rmSync` in `afterEach`. Seen on [run 34267252434](https://github.com/OpsMaxx/OpsMaxx/actions/runs/34267252434); a re-run of the identical commit passed. It struck a documentation-only PR.

The supervisor writes `<runId>.pid` under its `runRoot` on spawn and unlinks it when a run goes terminal, both fire-and-forget — `void unlink(...)` in `goTerminal`, a `.catch()`-swallowed `writeFile` in `writePidRecord`. Neither is awaitable from a test. `fs.promises` work runs on libuv's threadpool, so it proceeds **in parallel** with a synchronous `rmSync`: the walk empties a directory, a queued write puts a file back, the `rmdir` fails.

**Two obvious fixes are wrong, and I measured both rather than assuming.**

*Awaiting a real shutdown* — tracking every `Supervisor` and calling `stopAll()`, which is what `vpnFrpDriver` and `vpnWireguardDriver` already do — broke six tests and took the file from **5.7s to 66s**. `stop()` waits out the grace and kill windows on real timers for fake children that never exit.

*`maxRetries`* looks like the fix and does nothing, because `rmSync` is synchronous and its internal retries cannot yield to let pending writes finish:

| over 40 attempts, four writes in flight | failures |
|---|---|
| `force: true` alone | 20/40 |
| `+ maxRetries: 5, retryDelay: 20` | 20/40 |
| async retry loop | **0/40** |

The `await` is the entire difference. `tests/fixtures/rmTemp.ts` does that, and records the measurement so it does not get "simplified" back.

`processService` and `vpnReap` share the teardown and the writer, so they share the helper.

## 2. Three tests that fail when they mean "not built yet"

All three pass in CI, which runs `npm run build` before `npm run test`, and fail in a fresh checkout or a git worktree. The messages actively mislead: `MCP error -32000: Connection closed` reads like the config writer emitting something Codex cannot use.

- **`localPtySmoke`** looked for `../node_modules/@lydell/` beside the test file. A worktree has no `node_modules` of its own, so it failed `ENOENT` on every worktree branch. It asks the resolver now — which also checks the package that will actually be loaded rather than one at a guessed path.
- **`cliPairing` and `connectAgent`** spawn `out/cli/index.js` as a real MCP server. That is a build artifact, so they skip when it is absent and say so once per file. A silent skip is how a suite stays green while proving nothing.

## Verification

- Six consecutive runs of the three supervisor files: 49 passing, 5.7s — identical to baseline, no runtime cost.
- Unbuilt: 7 passed, 4 skipped, no failures.
- **After `npm run build` the guarded tests run and pass** — 10 passed, 0 failed — so nothing is hidden.
- Full suite with the build present: **331 files, 6979 tests, zero failures.**
- Lint and typecheck clean.

`CLAUDE.md` gains a short "Running the tests" note, since both of these cost time to rediscover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

