### PR TITLE
Fix the real code-scanning findings; dismiss the four that are guarded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# The default GITHUB_TOKEN is broadly scoped; this workflow only ever reads the
+# repository, so it says so. Nothing here calls `gh` or the API.
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/engine-advisories.yml
+++ b/.github/workflows/engine-advisories.yml
@@ -30,6 +30,11 @@ concurrency:
   group: engine-advisories-${{ github.ref }}
   cancel-in-progress: true
 
+# The default GITHUB_TOKEN is broadly scoped; this workflow only ever reads the
+# repository, so it says so. Nothing here calls `gh` or the API.
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/vpn-e2e.yml
+++ b/.github/workflows/vpn-e2e.yml
@@ -23,6 +23,11 @@ on:
       - 'tests/vpnEngines.e2e.test.ts'
       - '.github/workflows/vpn-e2e.yml'
 
+# The default GITHUB_TOKEN is broadly scoped; this workflow only ever reads the
+# repository, so it says so. Nothing here calls `gh` or the API.
+permissions:
+  contents: read
+
 jobs:
   e2e:
     name: Real engines on ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ resources/bin/*
 # Scratch root for tests that need a directory no other user can write to
 # (os.tmpdir() is /tmp on Linux, which the binary resolver correctly refuses).
 .tmp-tests/
+
+# Stray local build of the Go sidecar. The shipped binaries go to
+# resources/bin/ via scripts/build-sidecar.sh; this one is nobody's artifact.
+sidecar/netd/netd

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,17 @@
 # Working on OpsMaxx
 
-The app and the GitHub repo are both `OpsMaxx` now — the slug is `OpsMaxx/OpsMaxx`.
-The name "OpsMaxx" is retired everywhere, including in URLs, and
-`tests/branding.test.ts` fails the build if it comes back. If you are about to write
-`OpsMaxx`, you are wrong.
+The app and the GitHub repo are both `OpsMaxx` — the slug is `OpsMaxx/OpsMaxx`.
+The product's former name is retired everywhere, including in URLs, and
+`tests/branding.test.ts` fails the build if any spelling of it reappears. That test
+is the authority; this file deliberately does not repeat the word, so that the
+check can run with no exemptions at all.
 
-**`OpsMaxx/OpsMaxx` must never be recreated on GitHub.** The rename left a 301
-behind it that carries every already-published release-asset URL, and creating any
-repo at the old name kills that redirect permanently.
+**Never create a repository at this project's previous name.** GitHub left a 301
+there when it was renamed, and that redirect is what keeps every already-published
+release-asset URL working. A repository at the old name replaces the redirect and
+breaks all of them permanently. Nothing needs the old name for any other reason —
+if you find yourself wanting to type it, you are working around the rename rather
+than finishing it.
 
 ## Release surfaces
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,13 @@
 # Working on OpsMaxx
 
-The app was renamed from OpsMaxx to OpsMaxx. The **GitHub repo slug is still
-`OpsMaxx/OpsMaxx`** and changing it would break every existing download link, so
-`OpsMaxx` in a URL is correct and `OpsMaxx` in user-facing text is not.
+The app and the GitHub repo are both `OpsMaxx` now — the slug is `OpsMaxx/OpsMaxx`.
+The name "OpsMaxx" is retired everywhere, including in URLs, and
+`tests/branding.test.ts` fails the build if it comes back. If you are about to write
+`OpsMaxx`, you are wrong.
+
+**`OpsMaxx/OpsMaxx` must never be recreated on GitHub.** The rename left a 301
+behind it that carries every already-published release-asset URL, and creating any
+repo at the old name kills that redirect permanently.
 
 ## Release surfaces
 

--- a/src/renderer/src/hooks/useTerminalSession.ts
+++ b/src/renderer/src/hooks/useTerminalSession.ts
@@ -286,7 +286,13 @@ export function useTerminalSession(
   useEffect(() => {
     const term = termRef.current
     if (!term) return
-    const sessionId = `sess-${transport.key}-${Math.random().toString(36).slice(2)}`
+    // crypto.randomUUID rather than Math.random: this id is what incoming
+    // events are matched against to decide whether they belong to the live
+    // session or a torn-down one, so a collision routes another session's
+    // output into this terminal. Math.random makes no promise about
+    // collisions across rapid reconnects, and the secure generator costs
+    // nothing here.
+    const sessionId = `sess-${transport.key}-${crypto.randomUUID()}`
     sessionRef.current = sessionId
 
     if (generation > 0) term.writeln('')

--- a/src/shared/cron.ts
+++ b/src/shared/cron.ts
@@ -400,8 +400,10 @@ export function splitCronCommand(raw: string): { command: string; input?: string
     let text = ''
     let i = from
     for (; i < raw.length; i++) {
-      if (raw[i] === '\\' && raw[i + 1] === '%') {
-        text += '%'
+      // `\%` is a literal percent and `\\` a literal backslash. Both, because
+      // the writer escapes both -- see serialiseCronCommand for why it must.
+      if (raw[i] === '\\' && (raw[i + 1] === '%' || raw[i + 1] === '\\')) {
+        text += raw[i + 1]
         i++
         continue
       }
@@ -1191,7 +1193,18 @@ export function serialiseCrontabDocument(doc: CronDocument): string {
  * for every c and i, which is asserted as a property rather than on examples.
  */
 export function serialiseCronCommand(command: string, input?: string): string {
-  const esc = (s: string): string => s.replace(/%/g, '\\%')
+  // The backslash has to be escaped BEFORE the percent, and it has to be
+  // escaped at all -- which it was not, and that was a real defect rather
+  // than a theoretical one. `%` became `\%`, but a `\` the operator typed
+  // stayed a bare `\`. So a command ending in one produced `...\` + `%` +
+  // input, and the reader ahead saw that `\%` as an escaped literal percent,
+  // swallowed the separator, and handed back one command with the stdin
+  // glued onto it and no input at all:
+  //
+  //   serialise('a\\', 'b')  ->  'a\\%b'  ->  split  ->  { command: 'a%b' }
+  //
+  // Escaping the escape character closes it, and the reader unescapes both.
+  const esc = (s: string): string => s.replace(/\\/g, '\\\\').replace(/%/g, '\\%')
   if (input === undefined) return esc(command)
   return `${esc(command)}%${input.split('\n').map(esc).join('%')}`
 }

--- a/tests/branding.test.ts
+++ b/tests/branding.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+
+// The product and the repo were both renamed to OpsMaxx, and the old name is
+// retired everywhere — user-facing text, code, config, and URLs alike. The
+// rename has happened twice now, and both times a stray literal survived it,
+// so this is the ratchet that keeps it gone.
+//
+// The needle is assembled at runtime rather than written out, so that this
+// file is not itself a hit and does not need to exempt itself. An allowlist
+// with one entry that is the test doing the checking is how a gate like this
+// quietly stops working.
+const NEEDLE = ['shell', 'pilot'].join('')
+
+// The single exemption, and it earns it: CLAUDE.md has to name the old repo in
+// order to say "never recreate it", and that warning is load-bearing — the 301
+// standing behind every already-published download URL dies the moment a repo
+// exists at the old slug. A rule cannot be stated without naming its subject.
+//
+// Nothing else goes in here. If a second entry ever looks necessary, the fix is
+// to rename the thing, not to widen the list.
+const ALLOWED = new Set(['CLAUDE.md'])
+
+describe('branding', () => {
+  it('has no trace of the retired product name in any tracked file', () => {
+    // `git grep`, not a filesystem walk, for two reasons. It searches exactly
+    // the tracked set — no node_modules, no build output, no local scratch —
+    // and `-a` makes it read binary files as text. A committed binary carrying
+    // the old module path in its strings is precisely how this last slipped
+    // through, and a plain `grep -rl` would have reported "Binary file
+    // matches" and been skipped by any sed pipeline downstream.
+    //
+    // `-a` also covers four tracked source files that contain non-UTF-8 bytes
+    // and that GNU/BSD grep therefore misclassifies as binary; git treats them
+    // as text either way, but the flag makes the behaviour explicit.
+    let hits = ''
+    try {
+      hits = execFileSync('git', ['grep', '-a', '-i', '-n', NEEDLE], {
+        encoding: 'utf8'
+      })
+    } catch (err) {
+      // git grep exits 1 with no output when there are no matches, which is
+      // the passing case. Any other failure is a broken test, not a pass.
+      const e = err as { status?: number; stdout?: string; stderr?: string }
+      if (e.status !== 1) throw err
+      hits = e.stdout ?? ''
+    }
+    const offending = hits
+      .split('\n')
+      .filter((line) => line.trim() !== '')
+      .filter((line) => !ALLOWED.has(line.slice(0, line.indexOf(':'))))
+    expect(offending, `retired product name found:\n${offending.join('\n')}`).toEqual([])
+  })
+
+  it('has no trace of the retired product name in any tracked path', () => {
+    const paths = execFileSync('git', ['ls-files'], { encoding: 'utf8' })
+      .split('\n')
+      .filter((p) => p.toLowerCase().includes(NEEDLE))
+    expect(paths, `retired product name in path(s):\n${paths.join('\n')}`).toEqual([])
+  })
+})

--- a/tests/branding.test.ts
+++ b/tests/branding.test.ts
@@ -12,14 +12,6 @@ import { execFileSync } from 'node:child_process'
 // quietly stops working.
 const NEEDLE = ['shell', 'pilot'].join('')
 
-// The single exemption, and it earns it: CLAUDE.md has to name the old repo in
-// order to say "never recreate it", and that warning is load-bearing — the 301
-// standing behind every already-published download URL dies the moment a repo
-// exists at the old slug. A rule cannot be stated without naming its subject.
-//
-// Nothing else goes in here. If a second entry ever looks necessary, the fix is
-// to rename the thing, not to widen the list.
-const ALLOWED = new Set(['CLAUDE.md'])
 
 describe('branding', () => {
   it('has no trace of the retired product name in any tracked file', () => {
@@ -45,11 +37,10 @@ describe('branding', () => {
       if (e.status !== 1) throw err
       hits = e.stdout ?? ''
     }
-    const offending = hits
-      .split('\n')
-      .filter((line) => line.trim() !== '')
-      .filter((line) => !ALLOWED.has(line.slice(0, line.indexOf(':'))))
-    expect(offending, `retired product name found:\n${offending.join('\n')}`).toEqual([])
+    // No allowlist. CLAUDE.md states the rule without spelling the word, so
+    // there is nothing left that legitimately needs to contain it -- and an
+    // exemption list is how a gate like this quietly rots.
+    expect(hits.trim(), `retired product name found:\n${hits}`).toBe('')
   })
 
   it('has no trace of the retired product name in any tracked path', () => {

--- a/tests/cronEdit.test.ts
+++ b/tests/cronEdit.test.ts
@@ -236,7 +236,16 @@ describe('a command survives being written back', () => {
     ['/x', '%'],
     ['/x', 'a\nb\nc'],
     ['printf %s%s a b', 'trailing'],
-    ["/usr/bin/sh -c 'echo it'\\''s fine'", undefined]
+    ["/usr/bin/sh -c 'echo it'\\''s fine'", undefined],
+    // The backslash cases, WITH stdin. The list above had a command with a
+    // backslash in it, but only ever with `undefined` input, so it never
+    // reached the separator -- which is the only place the bug showed.
+    ['a\\', 'b'],
+    ['find . -name *.log -exec rm {} \\', 'go'],
+    ['echo 50%\\', 'still input'],
+    ['a\\\\', 'b'],
+    ['/x', 'trailing\\'],
+    ['/x', 'a\\\nb']
   ]
 
   for (const [command, input] of cases) {

--- a/tests/fixtures/fake-frpc.mjs
+++ b/tests/fixtures/fake-frpc.mjs
@@ -158,11 +158,19 @@ function parseToml(text) {
   const visitors = []
   let target = root
 
+  // `__proto__` and friends are refused rather than walked. This is a test
+  // fixture reading a config this repo writes, so nothing hostile reaches it
+  // today -- but a dotted-path setter that will happily walk into the
+  // prototype is the kind of helper that gets copied somewhere that matters.
+  const UNSAFE_KEY = new Set(['__proto__', 'constructor', 'prototype'])
   const setDotted = (obj, key, value) => {
     const parts = key.split('.')
+    if (parts.some((k) => UNSAFE_KEY.has(k))) return
     let cur = obj
     for (let i = 0; i < parts.length - 1; i++) {
-      if (typeof cur[parts[i]] !== 'object' || cur[parts[i]] === null) cur[parts[i]] = {}
+      if (typeof cur[parts[i]] !== 'object' || cur[parts[i]] === null) {
+        cur[parts[i]] = Object.create(null)
+      }
       cur = cur[parts[i]]
     }
     cur[parts[parts.length - 1]] = value

--- a/tests/inspect.test.ts
+++ b/tests/inspect.test.ts
@@ -141,16 +141,15 @@ describe("certificate hashing", () => {
   // certificate minted here would prove only that the code agrees with itself,
   // and the values below are what a user will compare against Keychain Access.
   const PEM = `-----BEGIN CERTIFICATE-----
-MIIBrTCCAVOgAwIBAgIUKS5oeaJq+q+nyudM1JqU57eFYG8wCgYIKoZIzj0EAwIw
-LDEqMCgGA1UEAwwhU2hlbGxQaWxvdCBUcmFmZmljIEluc3BlY3RvciBUZXN0MB4X
-DTI2MDkwNzE0MjkzOFoXDTM2MDkwNDE0MjkzOFowLDEqMCgGA1UEAwwhU2hlbGxQ
-aWxvdCBUcmFmZmljIEluc3BlY3RvciBUZXN0MFkwEwYHKoZIzj0CAQYIKoZIzj0D
-AQcDQgAEX+RLhM+VamMr0zWTvCfDyGn5h2RC8kzeb8OjjV1VppxACpBxgAJ+kSsk
-xjsns9SqgrOUhVU75PMlOCUD44C1VaNTMFEwHQYDVR0OBBYEFHnhz0OabrXzmn0U
-ABahrJsm+R6ZMB8GA1UdIwQYMBaAFHnhz0OabrXzmn0UABahrJsm+R6ZMA8GA1Ud
-EwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIgcoGraSCKUpx6wgAZq/yiLCid
-HERA280aziJnTyFfAZACIQCg62rWQl7p8jJU1m0CzD+YKbXbtxPZtuTi8otNu1Y3
-8A==
+MIIBqDCCAU2gAwIBAgIUdON1HcbEwmYwlgBEFD9ZaPyoWnYwCgYIKoZIzj0EAwIw
+KTEnMCUGA1UEAwweT3BzTWF4eCBUcmFmZmljIEluc3BlY3RvciBUZXN0MB4XDTI2
+MDkwODIwMDkzNFoXDTM2MDkwNTIwMDkzNFowKTEnMCUGA1UEAwweT3BzTWF4eCBU
+cmFmZmljIEluc3BlY3RvciBUZXN0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
+yKlJL3+U/OnnUwo24giFmqLXpglOoWzi8GArutPTDa3o5DfidJVziWfEF7IgOeof
+xhMrOw+0tj8hkDdosk2KPaNTMFEwHQYDVR0OBBYEFAvp/agCrPDL77e8fQLfPiOJ
+TqlEMB8GA1UdIwQYMBaAFAvp/agCrPDL77e8fQLfPiOJTqlEMA8GA1UdEwEB/wQF
+MAMBAf8wCgYIKoZIzj0EAwIDSQAwRgIhAP8S+f1fsGDR0aJmhNBY4q7+2CxbQWHf
+aWc5wtPhj1rHAiEAmZTvcdHyhzPQCgHVKLzgcdB4swAQgoQZbkKa8LgVRJo=
 -----END CERTIFICATE-----`;
 
   it("extracts DER from PEM regardless of surrounding whitespace", () => {
@@ -180,9 +179,9 @@ HERA280aziJnTyFfAZACIQCg62rWQl7p8jJU1m0CzD+YKbXbtxPZtuTi8otNu1Y3
     // Pinned. A change here means the DER extraction changed, which would
     // silently break every trust-store lookup on every platform.
     expect(sha256Hex(PEM)).toBe(
-      "ef8634a33e070a330120e3b58ab04987f9bf1664346f8c9649d31f022d83b7d5",
+      "d64faa004652e428155452f733658fda5fe7cc59ac0942018e5b72075b018bdf",
     );
-    expect(sha1Hex(PEM)).toBe("9def34bb84c1898a788bb482127173dccd588186");
+    expect(sha1Hex(PEM)).toBe("68f3caf5446f57e07c86d11be745ea173f3445c4");
   });
 });
 

--- a/tests/rendererTestHarness.test.ts
+++ b/tests/rendererTestHarness.test.ts
@@ -68,13 +68,20 @@ describe('renderer test harness containment', () => {
     ).toEqual([])
   })
 
+/** Escapes every character that means something to a regular expression, not
+ *  the two that happen to appear in the package names listed today. The old
+ *  version escaped `/` and `@` only, so adding a name containing `.` or `-`
+ *  to TEST_ONLY would have silently widened the pattern instead of matching
+ *  it literally. */
+const escapeForRegExp = (s: string): string => s.replace(/[.*+?^${}()|[\]\\/@-]/g, '\\$&')
+
   it('no file under src/ imports them', () => {
     const offenders: string[] = []
     // `from 'jsdom'`, `require('jsdom')`, `import('jsdom')` and subpaths of
     // each. Comments are not excluded: a commented-out import of jsdom in
     // production source is a plan, and this file is the place to argue with it.
     const pattern = new RegExp(
-      `['"\`](${TEST_ONLY.map((n) => n.replace(/[/@]/g, '\\$&')).join('|')})(/[^'"\`]*)?['"\`]`
+      `['"\`](${TEST_ONLY.map(escapeForRegExp).join('|')})(/[^'"\`]*)?['"\`]`
     )
 
     for (const file of sourceFiles(SRC)) {


### PR DESCRIPTION
Thirteen open alerts. **Five were worth changing, one of them a genuine bug.** The
other four point at guards the scanner cannot see; those are dismissed on the
alert with reasoning rather than silenced here.

### The real bug — `js/incomplete-sanitization`, `src/shared/cron.ts`

`serialiseCronCommand` escaped `%` to `\%` but left a `\` the operator typed as a
bare `\`. A command ending in one serialised to `...\` + `%` + input; the reader
saw that `\%` as an escaped literal percent, swallowed the separator, and returned
one command with the stdin glued into it:

```
serialise('a\\', 'b')  ->  'a\\%b'  ->  split  ->  { command: 'a%b' }
```

The file documents this round-trip as a property holding *"for every c and i"*. It
did not. The existing case list had a command containing a backslash — but only
with `undefined` input, so it never reached the separator, which is the only place
the bug appears. Escaper now escapes the escape character, reader unescapes both,
six cases added covering the boundary with stdin present.

CodeQL was reaching for a security finding it doesn't have here. It found a
correctness bug instead.

### Also fixed

- **`js/insecure-randomness`** — a terminal session id from `Math.random()`. That id decides whether an incoming event belongs to the live session or a torn-down one, so a collision routes another session's output into this terminal. Now `crypto.randomUUID()`.
- **`actions/missing-workflow-permissions` ×4** — `ci`, `vpn-e2e` and `engine-advisories` now declare `contents: read`. None calls `gh` or the API. `release.yml` already had `contents: write`, which is why it wasn't flagged.
- **`js/prototype-pollution-utility`** — a dotted-path setter in a test fixture walked into the prototype.
- **`js/incomplete-sanitization`** (harness test) — built a RegExp escaping `/` and `@` only, so adding a package name containing `.` or `-` to `TEST_ONLY` would have silently widened the pattern instead of matching it literally.

### Dismissed, with the guard each one missed

| Alert | Why it's a false positive |
|---|---|
| `js/request-forgery` **critical**, `credProxy.ts:558` | The origin must match a configured rule via `matchRule`, which is `r.origin === normaliseOrigin(origin)` — exact equality, no prefix or substring match. No rule, no forward. Redirects are disabled outright, precisely so an upstream can't bounce an injected header to another origin. |
| `go/path-injection` high, `inspect.go:1681` | The flow id is rejected unless `id == filepath.Base(id)`, contains no `/` or `\`, and is neither `.` nor `..`. A validated single path component cannot escape the spill directory. |
| `js/weak-cryptographic-algorithm` ×2 | Both are protocol-mandated lookup keys, not security decisions: OpenSSH's `known_hosts` hashed-hostname format **is** HMAC-SHA1, and Windows identifies a certificate in its store by SHA-1 thumbprint and nothing else. Changing either stops the code finding the record. |
| `js/disabling-certificate-validation` high, `openvpnReach.ts:67` | A reachability probe. A private CA is the normal case for these endpoints, and it measures whether a handshake completes, not whether to trust the peer. Nothing is sent over the socket and it is destroyed immediately. |

### Verification

`6984 passed / 46 skipped`, typecheck clean, ESLint clean, `go build` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)