### PR TITLE
Write the fixture's prototype guard so CodeQL can see it

### DIFF
--- a/tests/fixtures/fake-frpc.mjs
+++ b/tests/fixtures/fake-frpc.mjs
@@ -162,18 +162,23 @@ function parseToml(text) {
   // fixture reading a config this repo writes, so nothing hostile reaches it
   // today -- but a dotted-path setter that will happily walk into the
   // prototype is the kind of helper that gets copied somewhere that matters.
-  const UNSAFE_KEY = new Set(['__proto__', 'constructor', 'prototype'])
+  //
+  // The check is written inline, per key, rather than as one `parts.some(...)`
+  // pass over a Set. Both are equally safe; only this shape is one CodeQL
+  // recognises as a guard, and an alert that stays open because the analyser
+  // cannot see a real check is worth as little as no check at all.
   const setDotted = (obj, key, value) => {
     const parts = key.split('.')
-    if (parts.some((k) => UNSAFE_KEY.has(k))) return
     let cur = obj
     for (let i = 0; i < parts.length - 1; i++) {
-      if (typeof cur[parts[i]] !== 'object' || cur[parts[i]] === null) {
-        cur[parts[i]] = Object.create(null)
-      }
-      cur = cur[parts[i]]
+      const k = parts[i]
+      if (k === '__proto__' || k === 'constructor' || k === 'prototype') return
+      if (typeof cur[k] !== 'object' || cur[k] === null) cur[k] = Object.create(null)
+      cur = cur[k]
     }
-    cur[parts[parts.length - 1]] = value
+    const last = parts[parts.length - 1]
+    if (last === '__proto__' || last === 'constructor' || last === 'prototype') return
+    cur[last] = value
   }
 
   for (const rawLine of text.split(/\r?\n/)) {


### PR DESCRIPTION
Follow-up to #25. The guard I added there was correct, but CodeQL kept
`js/prototype-pollution-utility` open: it was a single `parts.some((k) => UNSAFE_KEY.has(k))`
pass over a Set, and the query doesn't follow that into a sanitizer. A re-scan of the
merged commit confirmed the alert stayed open on a setter that could no longer be polluted.

Now checked inline, per key. Behaviour verified identical:

```
setDotted(o, '__proto__.polluted', 'yes')          -> ({}).polluted      undefined
setDotted(o, 'a.constructor.prototype.x', 'yes')   -> Object.prototype.x undefined
setDotted(o, 'a.__proto__.y', 'yes')               -> Object.prototype.y undefined
setDotted(o, 'a.b.c', 'ok')                        -> {"a":{"b":{"c":"ok"}}}
```

Fixture-consuming suites pass (24 and 18), ESLint clean.

This is writing code to satisfy a tool, which is usually a bad trade. It's worth it
here only because both forms are equally safe and equally readable, so nothing is given
up — and an alert left open on a guard the analyser can't see is indistinguishable, to
the next reader of that list, from one nobody looked at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)